### PR TITLE
github actionsでlintが実行されるようにファイルを追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Cache node modules
+        uses: actions/cache@v2.1.4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: yarn install
+        run:  yarn install --check-files
+
+      - name: Rubocop
+        run: bundle exec rubocop
+
+      - name: JS Lint
+         run: bin/yarn lint


### PR DESCRIPTION
## issue
#44 [[RuboCopとESLintがCIで実行されるようにする](https://github.com/R-Tsukada/football-calendar/issues/44)]
## やったこと
LintがGitHub Actionsで実行されるようにした。
