### PR TITLE
lint.ymlのsyntax errorを修正

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,4 @@ jobs:
         run: bundle exec rubocop
 
       - name: JS Lint
-         run: bin/yarn lint
+        run: bin/yarn lint


### PR DESCRIPTION
## issue
#46 [CIのLintのsyntax errorを修正する]
## やったこと
CIのlintを実行するlint.ymlのsyntax errorを修正した
