### PR TITLE
リーグ一覧を表示するコードをコンポーネント化

### DIFF
--- a/app/javascript/components/LeagueList.vue
+++ b/app/javascript/components/LeagueList.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div class="container">
     <ul v-for="league in leagues" :key="league.id">

--- a/app/javascript/components/LeagueList.vue
+++ b/app/javascript/components/LeagueList.vue
@@ -1,0 +1,41 @@
+
+<template>
+  <div class="container">
+    <ul v-for="league in leagues" :key="league.id">
+      <li>
+        <img :src="league.logo" class="logo_image" />
+        <p>{{ league.name }}</p>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['leagues']
+}
+</script>
+
+<style scoped>
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: center;
+}
+
+ul {
+  list-style: none;
+}
+
+li {
+  border: solid 1px;
+  border-radius: 8px;
+  padding: 5px;
+  text-align: center;
+}
+
+p {
+  font-weight: bold;
+}
+</style>

--- a/app/javascript/components/page/league_list.vue
+++ b/app/javascript/components/page/league_list.vue
@@ -1,12 +1,6 @@
 <template>
   <div>
-    <div class="container">
-      <ul v-for="league in leagues" :key="league.id">
-        <li>
-          <img :src="league.logo" class="logo_image" />
-        </li>
-      </ul>
-    </div>
+    <LeagueList :leagues="leagues" />
     <TeamList :teams="teams" />
   </div>
 </template>
@@ -14,9 +8,11 @@
 <script>
 import axios from 'axios'
 import TeamList from '../TeamList.vue'
+import LeagueList from '../LeagueList.vue'
 
 export default {
   components: {
+    LeagueList,
     TeamList
   },
   data() {
@@ -45,14 +41,4 @@ export default {
 </script>
 
 <style scoped>
-.container {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-  justify-content: center;
-}
-
-ul {
-  list-style: none;
-}
 </style>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,7 @@ import Turbolinks from 'turbolinks'
 import * as ActiveStorage from '@rails/activestorage'
 import 'channels'
 
-require('../components/page/league_list.js')
+require('../page/team_select.js')
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/page/team_select.js
+++ b/app/javascript/page/team_select.js
@@ -1,5 +1,5 @@
 import { createApp } from 'vue'
-import App from './league_list.vue'
+import App from './team_select.vue'
 
 document.addEventListener('DOMContentLoaded', () => {
   const selector = '#js-league-list'

--- a/app/javascript/page/team_select.vue
+++ b/app/javascript/page/team_select.vue
@@ -7,8 +7,8 @@
 
 <script>
 import axios from 'axios'
-import TeamList from '../TeamList.vue'
-import LeagueList from '../LeagueList.vue'
+import TeamList from '../components/TeamList.vue'
+import LeagueList from '../components/LeagueList.vue'
 
 export default {
   components: {

--- a/app/javascript/page/team_select.vue
+++ b/app/javascript/page/team_select.vue
@@ -40,5 +40,4 @@ export default {
 }
 </script>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -42,16 +42,6 @@ class Team < ApplicationRecord
       team.logo = results['response'][result]['team']['logo']
       team.home_city = results['response'][result]['venue']['city']
       league = results['parameters']['league']
-      # team.league_id = case league
-      #                  when '39'
-      #                    37
-      #                  when '78'
-      #                    38
-      #                  when '135'
-      #                    39
-      #                  when '140'
-      #                    40
-      #                  end
       id = {
         '39' => 37,
         '78' => 38,


### PR DESCRIPTION
## 対応した issue
#58 [リーグ一覧をコンポーネント化する]
## 対応内容・対応背景・妥協点
リーグ一覧を表示するコードがコンポーネント化されておらず、pageファイルにベタ書きしていた。
## やったこと
- リーグ一覧を表示するコードをコンポーネント化した。
- componentsディレクトリにあったpageディレクトリを、それぞれ分けた。
## やってないこと
- UIが変わるような変更はしていない
## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
