### PR TITLE
Feature/add competitor team select

### DIFF
--- a/app/controllers/api/competitors_controller.rb
+++ b/app/controllers/api/competitors_controller.rb
@@ -1,12 +1,28 @@
 # frozen_string_literal: true
 
 class Api::CompetitorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  before_action :authenticate_user!
+  before_action :set_competitor_team, only: %i[create]
+
   def index
     user = current_user
     id = user.favorite.team_id
     team = Team.find(id)
     league = team.league_id
-    @team_id = team
     @competitor_teams = Team.where(league_id: league)
+  end
+
+  def create
+    user = current_user
+    user.competitor_team_follow(@competitor_teams)
+  end
+
+  private
+
+  def set_competitor_team
+    id = params.require(:competitor).permit(:id)
+    @competitor_teams = Team.find_by(id)
   end
 end

--- a/app/controllers/api/competitors_controller.rb
+++ b/app/controllers/api/competitors_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Api::CompetitorsController < ApplicationController
+  def index
+    user = current_user
+    id = user.favorite.team_id
+    team = Team.find(id)
+    league = team.league_id
+    @team_id = team
+    @competitor_teams = Team.where(league_id: league)
+  end
+end

--- a/app/controllers/api/favorites_controller.rb
+++ b/app/controllers/api/favorites_controller.rb
@@ -21,7 +21,7 @@ class Api::FavoritesController < ApplicationController
   private
 
   def set_follow
-    id = params.permit(:id)
+    id = params.require(:favorite).permit(:id)
     @team = Team.find_by(id)
   end
 end

--- a/app/controllers/api/favorites_controller.rb
+++ b/app/controllers/api/favorites_controller.rb
@@ -4,9 +4,14 @@ class Api::FavoritesController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   before_action :authenticate_user!
-  before_action :set_follow
+  before_action :set_follow, only: %i[create]
 
-  def index; end
+  def index
+    user = current_user
+    id = user.favorite.team_id
+    team = Team.find(id)
+    @favorite_team = team
+  end
 
   def create
     user = current_user

--- a/app/controllers/competitors_controller.rb
+++ b/app/controllers/competitors_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CompetitorsController < ApplicationController
+  def index; end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ import * as ActiveStorage from '@rails/activestorage'
 import 'channels'
 
 require('../page/team_select.js')
+require('../page/competitor_team_select.js')
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/page/competitor_team_select.js
+++ b/app/javascript/page/competitor_team_select.js
@@ -1,0 +1,11 @@
+import { createApp } from 'vue'
+import App from './competitor_team_select.vue'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const selector = '#js-competitors-select'
+  const app = document.querySelector(selector)
+  if (app) {
+    const app = createApp(App)
+    app.mount(selector)
+  }
+})

--- a/app/javascript/page/competitor_team_select.vue
+++ b/app/javascript/page/competitor_team_select.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="main">
+    <div class="container">
+      <ul v-for="team in teamFilter" :key="team.id">
+        <li>
+          <img :src="team.logo" />
+          <p>{{ team.name }}</p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+
+export default {
+  data() {
+    return {
+      teams: [],
+      favorite: ''
+    }
+  },
+  methods: {
+    setTeam: function () {
+      axios.get('/api/competitors').then((response) => {
+        this.teams = response.data
+      })
+    },
+    setFavoriteTeam: function () {
+      axios.get('/api/favorites').then((response) => {
+        this.favorite = response.data
+      })
+    }
+  },
+  computed: {
+    teamFilter() {
+      const number = this.favorite.id
+      return this.teams.filter(function (value) {
+        return value.id != number
+      })
+    }
+  },
+  mounted() {
+    this.setTeam()
+    this.setFavoriteTeam()
+  }
+}
+</script>
+
+<style scoped>
+.main {
+  text-align: center;
+}
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: center;
+}
+
+ul {
+  list-style: none;
+}
+
+li {
+  border: solid 1px;
+  border-radius: 8px;
+  padding: 5px;
+  text-align: center;
+}
+
+p {
+  font-weight: bold;
+}
+</style>

--- a/app/javascript/page/competitor_team_select.vue
+++ b/app/javascript/page/competitor_team_select.vue
@@ -2,23 +2,44 @@
   <div class="main">
     <div class="container">
       <ul v-for="team in teamFilter" :key="team.id">
-        <li>
-          <img :src="team.logo" />
+        <li @click="selectTeam(team)">
           <p>{{ team.name }}</p>
+          <img :src="team.logo" />
         </li>
       </ul>
     </div>
+    <button
+      class="add_favorite_team"
+      v-if="isAdding"
+      @click="addCompetitorTeams">
+      ライバルチームとして登録する
+    </button>
   </div>
 </template>
 
 <script>
 import axios from 'axios'
+import { createStore } from 'vuex'
+
+const store = createStore({
+  state() {
+    return {
+      teamId: []
+    }
+  },
+  mutations: {
+    increment(state, value) {
+      state.teamId = value
+    }
+  }
+})
 
 export default {
   data() {
     return {
       teams: [],
-      favorite: ''
+      favorite: '',
+      isAdding: true
     }
   },
   methods: {
@@ -31,6 +52,21 @@ export default {
       axios.get('/api/favorites').then((response) => {
         this.favorite = response.data
       })
+    },
+    addCompetitorTeams: function () {
+      axios
+        .post('/api/competitors', {
+          id: store.state.teamId
+        })
+        .then(function (response) {
+          console.log(response)
+        })
+        .catch(function (error) {
+          console.log(error)
+        })
+    },
+    selectTeam: function (team) {
+      store.commit('increment', team.id)
     }
   },
   computed: {

--- a/app/javascript/page/team_select.vue
+++ b/app/javascript/page/team_select.vue
@@ -16,9 +16,9 @@
         </li>
       </ul>
     </div>
-    <butto class="add_favorite_team" v-if="isShowing" @click="addFavoriteTeam"
-      >応援しているチームを決定する</butto
-    >
+    <button class="add_favorite_team" v-if="isShowing" @click="addFavoriteTeam">
+      応援しているチームを決定する
+    </button>
   </div>
 </template>
 

--- a/app/models/competitor.rb
+++ b/app/models/competitor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Competitor < ApplicationRecord
   belongs_to :user
   belongs_to :team

--- a/app/models/competitor.rb
+++ b/app/models/competitor.rb
@@ -1,0 +1,4 @@
+class Competitor < ApplicationRecord
+  belongs_to :user
+  belongs_to :team
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -9,6 +9,8 @@ class Team < ApplicationRecord
   belongs_to :league
   has_one :favorite, dependent: :destroy
 
+  has_many :competitor, dependent: :destroy
+
   require 'uri'
   require 'net/http'
   require 'openssl'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many :following, through: :favorite, source: :team
 
   has_many :competitor, dependent: :destroy
+  has_many :competitor_following, through: :competitor, source: :team
 
   def favorite_team_follow(team)
     following << team
@@ -27,15 +28,14 @@ class User < ApplicationRecord
   end
 
   def competitor_team_follow(team)
-    following << team
+    competitor_following << team
   end
 
   def competitor_team_unfollow(team)
-    Favorite.find_by(team: team.id).destroy
+    Competitor.find_by(team: team.id).destroy
   end
 
   def competitor_team_following?(team)
-    following.include?(team)
+    competitor_following.include?(team)
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,4 +25,17 @@ class User < ApplicationRecord
   def favorite_team_following?(team)
     following.include?(team)
   end
+
+  def competitor_team_follow(team)
+    following << team
+  end
+
+  def competitor_team_unfollow(team)
+    Favorite.find_by(team: team.id).destroy
+  end
+
+  def competitor_team_following?(team)
+    following.include?(team)
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   has_one :favorite, dependent: :destroy
   has_many :following, through: :favorite, source: :team
 
+  has_many :competitor, dependent: :destroy
+
   def favorite_team_follow(team)
     following << team
   end

--- a/app/views/api/competitors/index.json.jbuilder
+++ b/app/views/api/competitors/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @competitor_teams, :id, :name, :logo

--- a/app/views/api/favorites/index.json.jbuilder
+++ b/app/views/api/favorites/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.id @favorite_team.id

--- a/app/views/competitors/index.html.slim
+++ b/app/views/competitors/index.html.slim
@@ -1,0 +1,1 @@
+#js-competitors-select

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,6 @@ Rails.application.routes.draw do
     resources :leagues, only: [:index]
     resources :teams, only: [:index]
     resources :favorites, only: [:index, :create]
+    resources :competitors, only: [:index, :create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'leagues#index'
+  resources :competitors, only: [:index, :create]
   namespace :api, format: 'json' do
     resources :leagues, only: [:index]
     resources :teams, only: [:index]

--- a/db/migrate/20220402023240_create_competitors.rb
+++ b/db/migrate/20220402023240_create_competitors.rb
@@ -1,0 +1,10 @@
+class CreateCompetitors < ActiveRecord::Migration[6.1]
+  def change
+    create_table :competitors do |t|
+      t.references :user, foreign_key: true
+      t.references :team, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_31_013239) do
+ActiveRecord::Schema.define(version: 2022_04_02_023240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "competitors", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "team_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["team_id"], name: "index_competitors_on_team_id"
+    t.index ["user_id"], name: "index_competitors_on_user_id"
+  end
 
   create_table "favorites", force: :cascade do |t|
     t.bigint "user_id"
@@ -59,6 +68,8 @@ ActiveRecord::Schema.define(version: 2022_03_31_013239) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "competitors", "teams"
+  add_foreign_key "competitors", "users"
   add_foreign_key "favorites", "teams"
   add_foreign_key "favorites", "users"
   add_foreign_key "teams", "leagues"

--- a/spec/factories/competitors.rb
+++ b/spec/factories/competitors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :competitor do
     id { 1 }

--- a/spec/factories/competitors.rb
+++ b/spec/factories/competitors.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :competitor do
+    id { 1 }
+  end
+end

--- a/spec/models/competitor_spec.rb
+++ b/spec/models/competitor_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Competitor, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:league) { FactoryBot.create(:league) }
+  let(:team) { FactoryBot.build(:team, league: league)}
+
+  it 'is valid with a user_id and team_id' do
+    competitor = FactoryBot.build(:competitor, user: user, team: team)
+
+    expect(competitor).to be_valid
+  end
+
+  it 'is valid without a user_id' do
+    competitor = FactoryBot.build(:competitor, user: nil, team: team)
+
+    competitor.valid?
+    expect(competitor.errors[:user]).to include('must exist')
+  end
+
+  it 'is valid without a team' do
+    competitor = FactoryBot.build(:competitor, user: user, team: nil)
+
+    competitor.valid?
+    expect(competitor.errors[:team]).to include('must exist')
+  end
+end

--- a/spec/models/competitor_spec.rb
+++ b/spec/models/competitor_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Competitor, type: :model do
   let(:user) { FactoryBot.create(:user) }
   let(:league) { FactoryBot.create(:league) }
-  let(:team) { FactoryBot.build(:team, league: league)}
+  let(:team) { FactoryBot.build(:team, league: league) }
 
   it 'is valid with a user_id and team_id' do
     competitor = FactoryBot.build(:competitor, user: user, team: team)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,4 +52,14 @@ RSpec.describe User, type: :model do
     user.favorite_team_unfollow(team)
     expect(user.favorite_team_following?(team)).to_not be_truthy
   end
+
+  it 'is should competitor team follow a user' do
+    expect(user.competitor_team_following?(team)).to_not be_truthy
+
+    user.competitor_team_follow(team)
+    expect(user.competitor_team_following?(team)).to be_truthy
+
+    user.competitor_team_unfollow(team)
+    expect(user.competitor_team_following?(team)).to_not be_truthy
+  end
 end

--- a/spec/requests/api/competitors_spec.rb
+++ b/spec/requests/api/competitors_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Competitors", type: :request do
+  describe "post /index" do
+    it 'post http success' do
+      league = FactoryBot.create(:league)
+      team = FactoryBot.create(:team, league: league)
+      user = FactoryBot.create(:user)
+      sign_in user
+      post api_favorites_path, params: { id: team.id }
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/api/competitors_spec.rb
+++ b/spec/requests/api/competitors_spec.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Api::Competitors", type: :request do
-  describe "post /index" do
+RSpec.describe 'Api::Competitors', type: :request do
+  describe 'post /index' do
     it 'post http success' do
       league = FactoryBot.create(:league)
       team = FactoryBot.create(:team, league: league)
       user = FactoryBot.create(:user)
       sign_in user
-      post api_favorites_path, params: { id: team.id }
+      post api_competitors_path, params: { competitor: { id: team.id } }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/api/favorites_spec.rb
+++ b/spec/requests/api/favorites_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Favorites', type: :request do
       team = FactoryBot.create(:team, league: league)
       user = FactoryBot.create(:user)
       sign_in user
-      post api_favorites_path, params: { id: team.id }
+      post api_favorites_path, params: { favorite: { id: team.id } }
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
## 対応した issue
#64 
## 対応内容・対応背景・妥協点
ライバルチームを登録できるようにした。しかし現状は1チームしか登録できていない。
## やったこと
- Railsでチームをフォローする機能を追加
- vueで選択したチームのidを保存できるようにした
- 上記で保存したチームidをaxiosでpostできるようにした
## やってないこと
- デザイン
- 複数のチームを保存する機能（できなかった）
## UI before / after

<img width="1352" alt="Football" src="https://user-images.githubusercontent.com/62058863/161900856-234fc844-0ab6-4c84-9a40-8a5c42ec1c86.png">

## テスト
- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
