### PR TITLE
複数のチームをライバルチームとして登録できるようにした

### DIFF
--- a/app/controllers/api/competitors_controller.rb
+++ b/app/controllers/api/competitors_controller.rb
@@ -8,15 +8,16 @@ class Api::CompetitorsController < ApplicationController
 
   def index
     user = current_user
-    id = user.favorite.team_id
-    team = Team.find(id)
-    league = team.league_id
-    @competitor_teams = Team.where(league_id: league)
+    @competitor = user.competitor
   end
 
   def create
     user = current_user
-    user.competitor_team_follow(@competitor_teams)
+    if user.competitor_team_following?(@competitor_teams)
+      user.competitor_team_unfollow(@competitor_teams)
+    else
+      user.competitor_team_follow(@competitor_teams)
+    end
   end
 
   private

--- a/app/controllers/api/team_filter_controller.rb
+++ b/app/controllers/api/team_filter_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Api::TeamFilterController < ApplicationController
   before_action :authenticate_user!
 

--- a/app/controllers/api/team_filter_controller.rb
+++ b/app/controllers/api/team_filter_controller.rb
@@ -1,0 +1,11 @@
+class Api::TeamFilterController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    user = current_user
+    id = user.favorite.team_id
+    team = Team.find(id)
+    league = team.league_id
+    @filter = Team.where(league_id: league).where.not(id: team.id)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,11 +4,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   before_action :authenticate_user!
-  before_action :set_current_user
-
-  def set_current_user
-    User.current = current_user
-  end
 
   def after_sign_in_path_for(_resource)
     root_path

--- a/app/javascript/components/modal/CompetitorTeamCount.vue
+++ b/app/javascript/components/modal/CompetitorTeamCount.vue
@@ -1,0 +1,29 @@
+<template>
+  <article class="message is-info">
+    <div class="message-body">
+      <p>{{ teamCountMessage() }}</p>
+    </div>
+  </article>
+</template>
+
+<script>
+import { useStore } from 'vuex'
+export default {
+  setup() {
+
+    const store = useStore()
+
+    const teamCountMessage = () => {
+      const competitorLength = store.state.competitorTeamId.length
+      if (competitorLength <= 3) {
+        return `残り${3 - competitorLength}チーム登録できます`
+      } else {
+        return "登録できるのは3チームまでです"
+      }
+    }
+    return {
+      teamCountMessage
+    }
+  }
+}
+</script>

--- a/app/javascript/components/modal/CompetitorTeamCount.vue
+++ b/app/javascript/components/modal/CompetitorTeamCount.vue
@@ -10,7 +10,6 @@
 import { useStore } from 'vuex'
 export default {
   setup() {
-
     const store = useStore()
 
     const teamCountMessage = () => {
@@ -18,7 +17,7 @@ export default {
       if (competitorLength <= 3) {
         return `残り${3 - competitorLength}チーム登録できます`
       } else {
-        return "登録できるのは3チームまでです"
+        return '登録できるのは3チームまでです'
       }
     }
     return {

--- a/app/javascript/components/modal/CompetitorValidation.vue
+++ b/app/javascript/components/modal/CompetitorValidation.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <article class="message is-danger">
+        <div class="message-header">
+          <p>登録できるチーム数を超えています</p>
+          <button class="delete" aria-label="delete" @click="closeMessage"></button>
+        </div>
+        <div class="message-body">
+          ライバルチームとして登録できるチーム数は3チームまでです。
+        </div>
+    </article>
+  </div>
+</template>
+
+<script>
+import { useStore } from 'vuex'
+
+export default {
+    setup() {
+    const store = useStore()
+
+    const closeMessage = () => {
+      store.commit('openMessage')
+    }
+
+
+    return {
+      closeMessage,
+    }
+  }
+}
+</script>
+<style scoped>
+</style>

--- a/app/javascript/components/modal/CompetitorValidation.vue
+++ b/app/javascript/components/modal/CompetitorValidation.vue
@@ -1,13 +1,16 @@
 <template>
   <div>
     <article class="message is-danger">
-        <div class="message-header">
-          <p>登録できるチーム数を超えています</p>
-          <button class="delete" aria-label="delete" @click="closeMessage"></button>
-        </div>
-        <div class="message-body">
-          ライバルチームとして登録できるチーム数は3チームまでです。
-        </div>
+      <div class="message-header">
+        <p>登録できるチーム数を超えています</p>
+        <button
+          class="delete"
+          aria-label="delete"
+          @click="closeMessage"></button>
+      </div>
+      <div class="message-body">
+        ライバルチームとして登録できるチーム数は3チームまでです。
+      </div>
     </article>
   </div>
 </template>
@@ -16,19 +19,17 @@
 import { useStore } from 'vuex'
 
 export default {
-    setup() {
+  setup() {
     const store = useStore()
 
     const closeMessage = () => {
       store.commit('openMessage')
     }
 
-
     return {
-      closeMessage,
+      closeMessage
     }
   }
 }
 </script>
-<style scoped>
-</style>
+<style scoped></style>

--- a/app/javascript/components/page/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="main">
+    <article class="message is-info">
+      <div class="message-body">
+          <p>{{ teamCountMessage() }}</p>
+      </div>
+    </article>
     <div class="container">
       <ul v-for="team in data.teams" :key="team.id">
         <li>
@@ -49,6 +54,15 @@ export default {
       })
     }
 
+    const teamCountMessage = () => {
+      if (store.state.competitorTeamId.length === 0) {
+        return "登録したいチームを選んでください（最大3チーム）"
+      } else {
+        const count = 3 - store.state.competitorTeamId.length
+        return `残り${count}チーム登録できます`
+      }
+    }
+
     const toggleFollowAndUnfollowDisplay = (team) => {
       if (store.state.competitorTeamId.includes(team.id)) {
         return "解除する"
@@ -81,6 +95,7 @@ export default {
 
     return {
       data,
+      teamCountMessage,
       toggleFollowAndUnfollow,
       toggleFollowAndUnfollowDisplay,
       addCompetitor: () => store.commit('addCompetitor'),

--- a/app/javascript/components/page/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="main">
-  <CompetitorTeamSelect v-if="this.$store.state.isShowingMessage"/>
-  <CompetitorValidation v-else/>
+    <CompetitorTeamSelect v-if="this.$store.state.isShowingMessage" />
+    <CompetitorValidation v-else />
     <div class="container">
       <ul v-for="team in data.teams" :key="team.id">
         <li>
           <img :src="team.logo" class="team_logo_image" />
           <p>{{ team.name }}</p>
-          <button class="button" @click="toggleFollowAndUnfollow(team)">{{ toggleFollowAndUnfollowDisplay(team) }}</button>
+          <button class="button" @click="toggleFollowAndUnfollow(team)">
+            {{ toggleFollowAndUnfollowDisplay(team) }}
+          </button>
         </li>
       </ul>
     </div>
@@ -47,41 +49,45 @@ export default {
     const store = useStore()
 
     const setTeam = async () => {
-      axios.get('/api/team_filter').then((response) => {
-        data.teams = response.data
-      })
-      .catch(function (error) {
-        console.log(error)
-      })
+      axios
+        .get('/api/team_filter')
+        .then((response) => {
+          data.teams = response.data
+        })
+        .catch(function (error) {
+          console.log(error)
+        })
     }
 
     const toggleFollowAndUnfollowDisplay = (team) => {
       if (store.state.competitorTeamId.includes(team.id)) {
-        return "解除する"
+        return '解除する'
       } else {
-        return "フォローする"
+        return 'フォローする'
       }
     }
 
     const toggleFollowAndUnfollow = (team) => {
       if (store.state.competitorTeamId.includes(team.id)) {
-        axios.post('/api/competitors', {
-          id: team.id
-        })
-        .catch((error) => {
-          console.log(error)
-        })
+        axios
+          .post('/api/competitors', {
+            id: team.id
+          })
+          .catch((error) => {
+            console.log(error)
+          })
         store.commit('deleteCompetitor', team.id)
       } else if (store.state.competitorTeamId.length >= 3) {
         store.commit('closeMessage')
       } else {
         store.commit('addCompetitor', team.id)
-        axios.post('/api/competitors', {
-          id: team.id
-        })
-        .catch(function (error) {
-          console.log(error)
-        })
+        axios
+          .post('/api/competitors', {
+            id: team.id
+          })
+          .catch(function (error) {
+            console.log(error)
+          })
       }
     }
 
@@ -92,7 +98,7 @@ export default {
       toggleFollowAndUnfollow,
       toggleFollowAndUnfollowDisplay,
       addCompetitor: () => store.commit('addCompetitor'),
-      deleteCompetitor: () => store.commit('deleteCompetitor'),
+      deleteCompetitor: () => store.commit('deleteCompetitor')
     }
   }
 }

--- a/app/javascript/components/page/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="main">
-    <article class="message is-info">
-      <div class="message-body">
-          <p>{{ teamCountMessage() }}</p>
-      </div>
-    </article>
+  <CompetitorTeamSelect v-if="this.$store.state.isShowingMessage"/>
+  <CompetitorValidation v-else/>
     <div class="container">
       <ul v-for="team in data.teams" :key="team.id">
         <li>
@@ -32,9 +29,13 @@
 import axios from 'axios'
 import { reactive, onMounted } from 'vue'
 import { useStore } from 'vuex'
-
-
+import CompetitorValidation from '../modal/CompetitorValidation.vue'
+import CompetitorTeamSelect from '../modal/CompetitorTeamCount.vue'
 export default {
+  components: {
+    CompetitorValidation,
+    CompetitorTeamSelect
+  },
   setup() {
     const data = reactive({
       teams: [],
@@ -54,15 +55,6 @@ export default {
       })
     }
 
-    const teamCountMessage = () => {
-      if (store.state.competitorTeamId.length === 0) {
-        return "登録したいチームを選んでください（最大3チーム）"
-      } else {
-        const count = 3 - store.state.competitorTeamId.length
-        return `残り${count}チーム登録できます`
-      }
-    }
-
     const toggleFollowAndUnfollowDisplay = (team) => {
       if (store.state.competitorTeamId.includes(team.id)) {
         return "解除する"
@@ -80,6 +72,8 @@ export default {
           console.log(error)
         })
         store.commit('deleteCompetitor', team.id)
+      } else if (store.state.competitorTeamId.length >= 3) {
+        store.commit('closeMessage')
       } else {
         store.commit('addCompetitor', team.id)
         axios.post('/api/competitors', {
@@ -95,7 +89,6 @@ export default {
 
     return {
       data,
-      teamCountMessage,
       toggleFollowAndUnfollow,
       toggleFollowAndUnfollowDisplay,
       addCompetitor: () => store.commit('addCompetitor'),
@@ -130,9 +123,5 @@ li {
 
 p {
   font-weight: bold;
-}
-
-.borderColor {
-  border: solid 2px red;
 }
 </style>

--- a/app/javascript/components/page/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="main">
     <div class="container">
-      <ul v-for="team in teamFilter" :key="team.id">
+      <ul v-for="team in data.teams" :key="team.id">
         <li @click="selectTeam(team)">
+          <img :src="team.logo" class="team_logo_image" />
           <p>{{ team.name }}</p>
-          <img :src="team.logo" />
         </li>
       </ul>
     </div>
@@ -24,67 +24,36 @@
 
 <script>
 import axios from 'axios'
-import { useStore } from 'vuex'
-import { reactive, onMounted, computed } from 'vue'
+import { reactive, onMounted } from 'vue'
+/* import { useStore } from 'vuex' */
+
 
 export default {
   setup() {
     const data = reactive({
       teams: [],
-      favorite: '',
-      isAdding: true
+      isAdding: true,
+      isShowing: true
     })
-
-    const store = useStore()
 
     const setTeam = async () => {
-      axios.get('/api/competitors').then((response) => {
+      axios.get('/api/teams').then((response) => {
         data.teams = response.data
       })
-    }
-
-    const setFavoriteTeam = async () => {
-      axios.get('/api/favorites').then((response) => {
-        data.favorite = response.data
+      .then(function (response) {
+        console.log(response)
+      })
+      .catch(function (error) {
+        console.log(error)
       })
     }
-
-    const addCompetitorTeams = async () => {
-      axios
-        .post('/api/competitors', {
-          id: store.state.competitorTeamId
-        })
-        .then(function (response) {
-          console.log(response)
-        })
-        .catch(function (error) {
-          console.log(error)
-        })
-    }
-
-    const selectTeam = async (team) => {
-      store.commit('addCompetitor', team.id)
-    }
-
-    const teamFilter = computed(() => {
-      const number = data.favorite.id
-      return data.teams.filter(function (value) {
-        return value.id != number
-      })
-    })
 
     onMounted(() => {
-      setTeam(), setFavoriteTeam()
+      setTeam()
     })
 
     return {
-      data,
-      setTeam,
-      setFavoriteTeam,
-      addCompetitorTeams,
-      selectTeam,
-      teamFilter,
-      addCompetitor: () => store.commit('addCompetitor')
+      data
     }
   }
 }
@@ -115,5 +84,9 @@ li {
 
 p {
   font-weight: bold;
+}
+
+.borderColor {
+  border: solid 2px red;
 }
 </style>

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -1,10 +1,9 @@
 <template>
   <div class="main">
     <div class="container">
-      <p>{{ $store.state.favoriteTeamId }}</p>
       <ul v-for="league in data.leagues" :key="league.id">
         <li @click="selectLeague(league)">
-          <img :src="league.logo" class="logo_image" />
+          <img :src="league.logo" class="image is-96x96" />
           <p>{{ league.name }}</p>
         </li>
       </ul>
@@ -35,7 +34,6 @@ import { useStore } from 'vuex'
 export default {
   setup() {
     const data = reactive({
-      leagues: [],
       teams: [],
       leagueId: '',
       isShowing: false
@@ -53,6 +51,12 @@ export default {
       axios.get('/api/teams').then((response) => {
         data.teams = response.data
       })
+            .then(function (response) {
+        console.log(response)
+      })
+      .catch(function (error) {
+        console.log(error)
+      })
     }
 
     const addFavoriteTeam = async () => {
@@ -62,11 +66,12 @@ export default {
     }
 
     const selectLeague = (league) => {
-      data.leagueId = league.id
+      store.commit('addLeague', league.id)
+      console.log(store.state.favoriteLeagueId)
     }
 
     const teamFilter = computed(() => {
-      const number = data.leagueId
+      const number = store.state.favoriteLeagueId
       return data.teams.filter(function (value) {
         return value.league_id === number
       })
@@ -74,6 +79,7 @@ export default {
 
     const selectTeam = (team) => {
       store.commit('increment', team.id)
+      console.log(store.state.favoriteTeamId)
       data.isShowing = true
     }
 
@@ -81,8 +87,6 @@ export default {
 
     return {
       data,
-      setLeague,
-      setTeam,
       selectLeague,
       teamFilter,
       selectTeam,

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -51,12 +51,6 @@ export default {
       axios.get('/api/teams').then((response) => {
         data.teams = response.data
       })
-            .then(function (response) {
-        console.log(response)
-      })
-      .catch(function (error) {
-        console.log(error)
-      })
     }
 
     const addFavoriteTeam = async () => {
@@ -67,7 +61,6 @@ export default {
 
     const selectLeague = (league) => {
       store.commit('addLeague', league.id)
-      console.log(store.state.favoriteLeagueId)
     }
 
     const teamFilter = computed(() => {
@@ -79,7 +72,6 @@ export default {
 
     const selectTeam = (team) => {
       store.commit('increment', team.id)
-      console.log(store.state.favoriteTeamId)
       data.isShowing = true
     }
 

--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -4,7 +4,7 @@ export const store = createStore({
   state () {
     return {
       favoriteLeagueId: '',
-      favoriteTeamId: '',
+      favoriteTeamId: [],
       competitorTeamId: []
     }
   },
@@ -19,7 +19,7 @@ export const store = createStore({
       state.competitorTeamId.push(value)
     },
     deleteCompetitor (state, value) {
-      return state.competitorTeamId.filter(c => c !== value)
+      state.competitorTeamId = state.competitorTeamId.filter(competitor => competitor !== value)
     }
   }
 })

--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -1,4 +1,5 @@
 import { createStore } from 'vuex'
+import createPersistedState from 'vuex-persistedstate'
 
 export const store = createStore({
   state () {
@@ -21,5 +22,8 @@ export const store = createStore({
     deleteCompetitor (state, value) {
       state.competitorTeamId = state.competitorTeamId.filter(competitor => competitor !== value)
     }
-  }
+  },
+  plugins: [
+    createPersistedState()
+  ]
 })

--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -6,7 +6,8 @@ export const store = createStore({
     return {
       favoriteLeagueId: '',
       favoriteTeamId: [],
-      competitorTeamId: []
+      competitorTeamId: [],
+      isShowingMessage: true
     }
   },
   mutations: {
@@ -21,6 +22,12 @@ export const store = createStore({
     },
     deleteCompetitor (state, value) {
       state.competitorTeamId = state.competitorTeamId.filter(competitor => competitor !== value)
+    },
+    closeMessage (state) {
+      state.isShowingMessage = false
+    },
+    openMessage (state) {
+      state.isShowingMessage = true
     }
   },
   plugins: [

--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -1,18 +1,25 @@
 import { createStore } from 'vuex'
 
 export const store = createStore({
-  state() {
+  state () {
     return {
+      favoriteLeagueId: '',
       favoriteTeamId: '',
-      competitorTeamId: ''
+      competitorTeamId: []
     }
   },
   mutations: {
-    increment(state, value) {
+    increment (state, value) {
       state.favoriteTeamId = value
     },
-    addCompetitor(state, value) {
-      state.competitorTeamId = value
+    addLeague (state, value) {
+      state.favoriteLeagueId = value
+    },
+    addCompetitor (state, value) {
+      state.competitorTeamId.push(value)
+    },
+    deleteCompetitor (state, value) {
+      return state.competitorTeamId.filter(c => c !== value)
     }
   }
 })

--- a/app/javascript/store/store.js
+++ b/app/javascript/store/store.js
@@ -2,7 +2,7 @@ import { createStore } from 'vuex'
 import createPersistedState from 'vuex-persistedstate'
 
 export const store = createStore({
-  state () {
+  state() {
     return {
       favoriteLeagueId: '',
       favoriteTeamId: [],
@@ -11,26 +11,26 @@ export const store = createStore({
     }
   },
   mutations: {
-    increment (state, value) {
+    increment(state, value) {
       state.favoriteTeamId = value
     },
-    addLeague (state, value) {
+    addLeague(state, value) {
       state.favoriteLeagueId = value
     },
-    addCompetitor (state, value) {
+    addCompetitor(state, value) {
       state.competitorTeamId.push(value)
     },
-    deleteCompetitor (state, value) {
-      state.competitorTeamId = state.competitorTeamId.filter(competitor => competitor !== value)
+    deleteCompetitor(state, value) {
+      state.competitorTeamId = state.competitorTeamId.filter(
+        (competitor) => competitor !== value
+      )
     },
-    closeMessage (state) {
+    closeMessage(state) {
       state.isShowingMessage = false
     },
-    openMessage (state) {
+    openMessage(state) {
       state.isShowingMessage = true
     }
   },
-  plugins: [
-    createPersistedState()
-  ]
+  plugins: [createPersistedState()]
 })

--- a/app/views/api/competitors/index.json.jbuilder
+++ b/app/views/api/competitors/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @competitor_teams, :id, :name, :logo
+json.array! @competitor, :id

--- a/app/views/api/team_filter/index.json.jbuilder
+++ b/app/views/api/team_filter/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @filter, :id, :name, :logo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,6 @@ Rails.application.routes.draw do
     resources :favorites, only: [:index, :create]
     resources :competitors, only: [:index, :create]
     resources :standings, only: [:index, :show]
+    resources :team_filter, only: [:index]
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,5 @@
 version: "3.9"
 services:
-  webpacker:
-    build: .
-    environment:
-      - NODE_ENV=development
-      - RAILS_ENV=development
-      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
-    command: ./bin/webpack-dev-server
-    volumes:
-      - .:/webpacker-example-app
-    ports:
-      - '3035:3035'
   db:
     image: postgres
     volumes:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vue-loader": "^17.0.0",
     "vue-router": "^4.0.14",
     "vuex": "^4.0.2",
+    "vuex-persistedstate": "^4.1.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },

--- a/spec/requests/api/team_filter_spec.rb
+++ b/spec/requests/api/team_filter_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "Api::TeamFilters", type: :request do
+  describe "GET /api/team_filter" do
+    it "returns http success" do
+      league = FactoryBot.create(:league)
+      team = FactoryBot.create(:team, league: league)
+      user = FactoryBot.build(:user)
+      sign_in user
+      user.favorite_team_follow(team)
+      get api_team_filter_index_path(format: :json)
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/api/team_filter_spec.rb
+++ b/spec/requests/api/team_filter_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Api::TeamFilters", type: :request do
-  describe "GET /api/team_filter" do
-    it "returns http success" do
+RSpec.describe 'Api::TeamFilters', type: :request do
+  describe 'GET /api/team_filter' do
+    it 'returns http success' do
       league = FactoryBot.create(:league)
       team = FactoryBot.create(:team, league: league)
       user = FactoryBot.build(:user)
@@ -12,5 +14,4 @@ RSpec.describe "Api::TeamFilters", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2660,6 +2660,11 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz"
@@ -6799,6 +6804,11 @@ shell-quote@^1.6.1:
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
+shvl@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
+  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz"
@@ -7668,6 +7678,14 @@ vue@^3.2.31:
     "@vue/runtime-dom" "3.2.31"
     "@vue/server-renderer" "3.2.31"
     "@vue/shared" "3.2.31"
+
+vuex-persistedstate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz#127165f85f5b4534fb3170a5d3a8be9811bd2a53"
+  integrity sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.3"
 
 vuex@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## 対応した issue
#72 
## 対応内容・対応背景・妥協点
- 複数のチームをフォローできるようにした
- Vueファイルにバリデーションを追加
## やったこと
- 複数のチームをフォローできるようにした
- フォローを解除できるようにした
- 3チーム以上を登録できないようにした
- 4チーム目を登録しようとしたら注意のメッセージが表示されるようにした
## やってないこと
- Rails側のバリデーションは追加していない
## UI before / after
### before
<img width="1438" alt="Football" src="https://user-images.githubusercontent.com/62058863/163325739-4a42b9b1-6a56-47a8-8847-b29d5a835e32.png">

### after
<img width="1472" alt="Football" src="https://user-images.githubusercontent.com/62058863/163325409-c7f3319e-07ea-4150-8a98-7ccaec364687.png">

[![Image from Gyazo](https://i.gyazo.com/3d300e7bacb7ca2f27f7d1c6fa0e1881.gif)](https://gyazo.com/3d300e7bacb7ca2f27f7d1c6fa0e1881)

[![Image from Gyazo](https://i.gyazo.com/4db6b0cdfe4c07777a05f05a345866e5.gif)](https://gyazo.com/4db6b0cdfe4c07777a05f05a345866e5)

## テスト
- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
