### PR TITLE
リーグ戦情報に試合予定が表示されるようにした

### DIFF
--- a/app/controllers/api/favorite_team_matches_controller.rb
+++ b/app/controllers/api/favorite_team_matches_controller.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class Api::FavoriteTeamMatchesController < ApplicationController
+  before_action :set_match
+  require 'uri'
+  require 'net/http'
+  require 'openssl'
+  require 'json'
+
+  def index
+  end
+
+  private
+
+  def set_match
+    Match.delete_all
+    api_request
+  end
+
+  def api_request
+    api_request_url.each do |url|
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+      request = Net::HTTP::Get.new(url)
+      request['x-rapidapi-host'] = ENV['HOST']
+      request['x-rapidapi-key'] = ENV['KEY']
+
+      response = http.request(request)
+      results = JSON.parse(response.body)
+      api = results
+      save_match(api)
+    end
+  end
+
+  def save_match(api)
+    api['response'].each_index do |a|
+      match = Match.new
+      match.season = [api][0]['parameters']['season']
+      match.team_matches_index = [api][0]['parameters']['team']
+      match.date = [api][0]['response'][a]['fixture']['date'].scan(/\d\d\d\d-\d\d-\d\d/).join('')
+      stadium = [api][0]['response'][a]['fixture']['venue']['name']
+      match.home_and_away = stadium == favorite_team_stadium ? 'HOME' : 'AWAY'
+      match.competition_name = [api][0]['response'][a]['league']['name']
+      match.competition_logo = [api][0]['response'][a]['league']['logo']
+      home_team_name = [api][0]['response'][a]['teams']['home']['name']
+      away_team_name = [api][0]['response'][a]['teams']['away']['name']
+      current_team = Team.find_by(api_id: match.team_matches_index)
+      match.team_name = home_team_name == current_team.name ? away_team_name : home_team_name
+      home_logo = [api][0]['response'][a]['teams']['home']['logo']
+      away_logo = [api][0]['response'][a]['teams']['away']['logo']
+      match.team_logo = home_logo == current_team.logo ? away_logo : home_logo
+      match.home_score = [api][0]['response'][a]['score']['fulltime']['home']
+      match.away_score = [api][0]['response'][a]['score']['fulltime']['away']
+      match.save
+    end
+  end
+
+  def api_request_url
+    api_ids = competitor_teams.unshift(favorite_team_api_id)
+    api_ids.map { |i| URI("https://v3.football.api-sports.io/fixtures?&season=#{season_year}&team=#{i}") }
+  end
+
+  def competitor_teams
+    @user = current_user
+    competitor_team_id = @user.competitor.map(&:team_id)
+    competitor_team_id.map { |c| Team.find(c).api_id }
+  end
+
+  def favorite_team_api_id
+    favorite_team_id = @user.favorite.team_id
+    Team.find(favorite_team_id).api_id
+  end
+
+  def favorite_team_name
+    id = @user.favorite.team_id
+    team = Team.find(id)
+    team.name
+  end
+
+  def favorite_team_stadium
+    id = @user.favorite.id
+    team = Team.find(id)
+    team.stadium
+  end
+
+  def season_year
+    current_year = Time.zone.now.year
+    current_month = Time.zone.now.month
+    current_month <= 7 ? current_year - 1 : current_year
+  end
+end

--- a/app/controllers/api/favorite_team_matches_controller.rb
+++ b/app/controllers/api/favorite_team_matches_controller.rb
@@ -8,6 +8,10 @@ class Api::FavoriteTeamMatchesController < ApplicationController
   require 'json'
 
   def index
+    user = current_user
+    favorite_team = user.favorite.team_id
+    current_team = Team.find(favorite_team).api_id
+    @match = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
   end
 
   private

--- a/app/controllers/api/first_competitor_team_matches_controller.rb
+++ b/app/controllers/api/first_competitor_team_matches_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Api::FirstCompetitorTeamMatchesController < ApplicationController
+  def index
+    user = current_user
+    competitor_teams = user.competitor.map(&:team_id)
+    current_team = Team.find(competitor_teams[0]).api_id
+    @first_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
+  end
+end

--- a/app/controllers/api/secound_competitor_team_matches_controller.rb
+++ b/app/controllers/api/secound_competitor_team_matches_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Api::SecoundCompetitorTeamMatchesController < ApplicationController
+  def index
+    user = current_user
+    competitor_teams = user.competitor.map(&:team_id)
+    current_team = Team.find(competitor_teams[1]).api_id
+    @secound_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
+  end
+end

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -59,7 +59,7 @@ class Api::StandingsController < ApplicationController
 
   def competitor_team_api_id
     @user = current_user
-    competitor_team_id = @user.competitor.map { |c| c.team_id }
+    competitor_team_id = @user.competitor.map(&:team_id)
     competitor_team_id.map { |c| Team.find(c).api_id }
   end
 

--- a/app/controllers/api/standings_controller.rb
+++ b/app/controllers/api/standings_controller.rb
@@ -53,14 +53,14 @@ class Api::StandingsController < ApplicationController
   end
 
   def api_request_url
-    team_numbers = [favorite_team_api_id, competitor_team_api_id]
+    team_numbers = competitor_team_api_id.unshift(favorite_team_api_id)
     team_numbers.map { |number| URI("https://v3.football.api-sports.io/standings?league=#{league_api_id}&season=#{season_year}&team=#{number}") }
   end
 
   def competitor_team_api_id
-    competitor_team_id = current_user.competitor[0].team_id
-    competitor_team = Team.find(competitor_team_id)
-    competitor_team.api_id
+    @user = current_user
+    competitor_team_id = @user.competitor.map { |c| c.team_id }
+    competitor_team_id.map { |c| Team.find(c).api_id }
   end
 
   def league_api_id

--- a/app/controllers/api/third_competitor_team_matches_controller.rb
+++ b/app/controllers/api/third_competitor_team_matches_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Api::ThirdCompetitorTeamMatchesController < ApplicationController
+  def index
+    user = current_user
+    competitor_teams = user.competitor.map(&:team_id)
+    current_team = Team.find(competitor_teams[2]).api_id
+    @third_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
+  end
+end

--- a/app/helpers/api/leagues_helper.rb
+++ b/app/helpers/api/leagues_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module Api::LeaguesHelper
-end

--- a/app/javascript/components/page/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect.vue
@@ -42,8 +42,7 @@ export default {
     const data = reactive({
       teams: [],
       competitors: [],
-      isAdding: true,
-      isShowing: true
+      isAdding: true
     })
 
     const store = useStore()

--- a/app/javascript/components/page/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule.vue
@@ -12,15 +12,18 @@
           <th><abbr title="Shedule">次節以降の試合</abbr></th>
         </tr>
       </thead>
-      <tbody>
-        <tr v-for="schedule in data.schedules" :key="schedule.id">
-          <th>{{ schedule.rank }}</th>
-          <th><img :src="schedule.team_logo" class="image is-48x48" /></th>
-          <th>{{ schedule.points }}</th>
-          <th>{{ schedule.played }}</th>
-          <th></th>
-        </tr>
-      </tbody>
+      <FavoriteTeamTable
+        :standings="data.favoriteTeams"
+        :matchSchedules="data.favoriteMatchSchedules" />
+      <FavoriteTeamTable
+        :standings="data.firstCompetitorTeams"
+        :matchSchedules="data.firstCompetitorMatchSchedules" />
+      <FavoriteTeamTable
+        :standings="data.secoundCompetitorTeams"
+        :matchSchedules="data.secoundCompetitorMatchSchedules" />
+      <FavoriteTeamTable
+        :standings="data.thirdCompetitorTeams"
+        :matchSchedules="data.thirdCompetitorMatchSchedules" />
     </table>
     <br />
     <button class="button">
@@ -35,26 +38,67 @@
 <script>
 import axios from 'axios'
 import { reactive, onMounted } from 'vue'
+import FavoriteTeamTable from '../table/FavoriteTeamTable.vue'
 
 export default {
+  components: {
+    FavoriteTeamTable
+  },
   setup() {
     const data = reactive({
-      schedules: []
+      favoriteTeams: [],
+      firstCompetitorTeams: [],
+      secoundCompetitorTeams: [],
+      thirdCompetitorTeams: [],
+      favoriteMatchSchedules: [],
+      firstCompetitorMatchSchedules: [],
+      secoundCompetitorMatchSchedules: [],
+      thirdCompetitorMatchSchedules: []
     })
 
-    const setSchedules = async () => {
+    const setTeamSchedules = async () => {
       axios.get('/api/standings').then((response) => {
-        data.schedules = response.data
+        data.favoriteTeams = response.data[0]
+        data.firstCompetitorTeams = response.data[1]
+        data.secoundCompetitorTeams = response.data[2]
+        data.thirdCompetitorTeams = response.data[3]
+      })
+    }
+
+    const setMatchSchedules = async () => {
+      axios.get('/api/favorite_team_matches').then((response) => {
+        data.favoriteMatchSchedules = response.data
+      })
+    }
+
+    const setFirstCompetitorMatchSchedules = async () => {
+      axios.get('/api/first_competitor_team_matches').then((response) => {
+        data.firstCompetitorMatchSchedules = response.data
+      })
+    }
+
+    const setSecoundCompetitorMatchSchedules = async () => {
+      axios.get('/api/secound_competitor_team_matches').then((response) => {
+        data.secoundCompetitorMatchSchedules = response.data
+      })
+    }
+
+    const setThirdCompetitorMatchSchedules = async () => {
+      axios.get('/api/third_competitor_team_matches').then((response) => {
+        data.thirdCompetitorMatchSchedules = response.data
       })
     }
 
     onMounted(() => {
-      setSchedules()
+      setTeamSchedules(),
+        setMatchSchedules(),
+        setFirstCompetitorMatchSchedules(),
+        setSecoundCompetitorMatchSchedules(),
+        setThirdCompetitorMatchSchedules()
     })
 
     return {
-      data,
-      setSchedules
+      data
     }
   }
 }

--- a/app/javascript/components/table/FavoriteTeamTable.vue
+++ b/app/javascript/components/table/FavoriteTeamTable.vue
@@ -6,12 +6,16 @@
       <th>{{ standings.points }}</th>
       <th>{{ standings.played }}</th>
       <th v-for="match in matchSchedules" :key="match.id">
-        <img :src="match.competition_logo" class="image is-24x24" />
-        <p>{{ match.date }}</p>
-        <p>{{ match.home_and_away }}</p>
-        <br />
-        <img :src="match.team_logo" class="image is-48x48" />
-        <p>{{ match.team_name }}</p>
+        <div class="match_schedules">
+          <div>
+            <img :src="match.competition_logo" class="image is-24x24" />
+            <p>{{ match.home_and_away }}</p>
+          </div>
+          <div>
+            <p>{{ match.date }}</p>
+            <img :src="match.team_logo" class="image is-48x48" />
+          </div>
+        </div>
       </th>
     </tr>
   </tbody>
@@ -22,3 +26,11 @@ export default {
   props: ['standings', 'matchSchedules']
 }
 </script>
+
+<style>
+.match_schedules {
+  display: flex;
+  border: solid 1px;
+  border-radius: 8px;
+}
+</style>

--- a/app/javascript/components/table/FavoriteTeamTable.vue
+++ b/app/javascript/components/table/FavoriteTeamTable.vue
@@ -1,0 +1,24 @@
+<template>
+  <tbody>
+    <tr class="team_standing">
+      <th>{{ standings.rank }}</th>
+      <th><img :src="standings.team_logo" class="image is-48x48" /></th>
+      <th>{{ standings.points }}</th>
+      <th>{{ standings.played }}</th>
+      <th v-for="match in matchSchedules" :key="match.id">
+        <img :src="match.competition_logo" class="image is-24x24" />
+        <p>{{ match.date }}</p>
+        <p>{{ match.home_and_away }}</p>
+        <br />
+        <img :src="match.team_logo" class="image is-48x48" />
+        <p>{{ match.team_name }}</p>
+      </th>
+    </tr>
+  </tbody>
+</template>
+
+<script>
+export default {
+  props: ['standings', 'matchSchedules']
+}
+</script>

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Match < ApplicationRecord
+  validates :team_matches_index, presence: true
+  validates :season, presence: true
+  validates :date, presence: true
+  validates :competition_name, presence: true
+  validates :competition_logo, presence: true
+  validates :team_name, presence: true
+  validates :team_logo, presence: true
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -8,4 +8,5 @@ class Match < ApplicationRecord
   validates :competition_logo, presence: true
   validates :team_name, presence: true
   validates :team_logo, presence: true
+  validates :home_and_away, presence: true
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -44,6 +44,7 @@ class Team < ApplicationRecord
       team.name = results['response'][result]['team']['name']
       team.logo = results['response'][result]['team']['logo']
       team.home_city = results['response'][result]['venue']['city']
+      team.stadium = results['response'][result]['venue']['name']
       league = results['parameters']['league']
       id = {
         '39' => 1,

--- a/app/views/api/competitors/index.json.jbuilder
+++ b/app/views/api/competitors/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @competitor, :id
+json.array! @competitor, :team_id

--- a/app/views/api/favorite_team_matches/index.json.jbuilder
+++ b/app/views/api/favorite_team_matches/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @match, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away

--- a/app/views/api/first_competitor_team_matches/index.json.jbuilder
+++ b/app/views/api/first_competitor_team_matches/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @first_competitor_team_matches, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away

--- a/app/views/api/secound_competitor_team_matches/index.json.jbuilder
+++ b/app/views/api/secound_competitor_team_matches/index.json.jbuilder
@@ -1,0 +1,2 @@
+json.array! @secound_competitor_team_matches, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away
+

--- a/app/views/api/third_competitor_team_matches/index.json.jbuilder
+++ b/app/views/api/third_competitor_team_matches/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @third_competitor_team_matches, :team_matches_index, :season, :date, :competition_name, :competition_logo, :team_name, :team_logo, :home_and_away

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Football
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.time_zone = 'Tokyo'
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,9 @@ Rails.application.routes.draw do
     resources :competitors, only: [:index, :create]
     resources :standings, only: [:index, :show]
     resources :team_filter, only: [:index]
+    resources :favorite_team_matches, only: [:index]
+    resources :first_competitor_team_matches, only: [:index]
+    resources :secound_competitor_team_matches, only: [:index]
+    resources :third_competitor_team_matches, only: [:index]
   end
 end

--- a/db/migrate/20220414064139_create_matches.rb
+++ b/db/migrate/20220414064139_create_matches.rb
@@ -1,0 +1,18 @@
+class CreateMatches < ActiveRecord::Migration[6.1]
+  def change
+    create_table :matches do |t|
+      t.integer :team_matches_index
+      t.string :season, null: false
+      t.date :date, null: false
+      t.string :competition_name, null: false
+      t.string :competition_logo, null: false
+      t.string :team_name, null: false
+      t.string :team_logo, null: false
+      t.string :home_score
+      t.string :away_score
+      t.string :home_and_away, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220416035353_add_stadium_teams.rb
+++ b/db/migrate/20220416035353_add_stadium_teams.rb
@@ -1,0 +1,5 @@
+class AddStadiumTeams < ActiveRecord::Migration[6.1]
+  def change
+    add_column :teams, :stadium, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_06_083254) do
+ActiveRecord::Schema.define(version: 2022_04_16_035353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,21 @@ ActiveRecord::Schema.define(version: 2022_04_06_083254) do
     t.index ["name"], name: "index_leagues_on_name", unique: true
   end
 
+  create_table "matches", force: :cascade do |t|
+    t.integer "team_matches_index"
+    t.string "season", null: false
+    t.date "date", null: false
+    t.string "competition_name", null: false
+    t.string "competition_logo", null: false
+    t.string "team_name", null: false
+    t.string "team_logo", null: false
+    t.string "home_score"
+    t.string "away_score"
+    t.string "home_and_away", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "standings", force: :cascade do |t|
     t.bigint "team_id"
     t.string "team_name", null: false
@@ -63,6 +78,7 @@ ActiveRecord::Schema.define(version: 2022_04_06_083254) do
     t.bigint "league_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "stadium"
     t.index ["api_id"], name: "index_teams_on_api_id", unique: true
     t.index ["league_id"], name: "index_teams_on_league_id"
     t.index ["logo"], name: "index_teams_on_logo", unique: true

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :match do
+    id { 1 }
+    date { 'Wed, 12 Jan 2022' }
+    team_matches_index { 1 }
+    season { 2021 }
+    competition_name { 'UEFA Champions League' }
+    competition_logo { 'https://media.api-sports.io/football/leagues/2.png' }
+    team_name { 'Villarreal' }
+    team_logo { 'https://media.api-sports.io/football/teams/533.png' }
+    home_score { '1' }
+    away_score { '1' }
+    home_and_away { 'AWAY' }
+  end
+end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -7,5 +7,13 @@ FactoryBot.define do
     sequence(:logo) { |n| "https://media.api-sports.io/football/teams/#{n}.png" }
     sequence(:api_id) { |n| n }
     home_city { 'London' }
+
+    trait :arsenal do
+      id { 1 }
+      name { 'Arsenal' }
+      logo { 'https://media.api-sports.io/football/teams/42.png' }
+      api_id { 42 }
+      home_city { 'London' }
+    end
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :team do
-    id { 1 }
-    name { 'Arsenal' }
-    logo { 'https://media.api-sports.io/football/teams/42.png' }
-    api_id { '42' }
+    sequence(:id) { |n| n }
+    sequence(:name) { |n| n }
+    sequence(:logo) { |n| "https://media.api-sports.io/football/teams/#{n}.png" }
+    sequence(:api_id) { |n| n }
     home_city { 'London' }
   end
 end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Match, type: :model do
+  it 'is valid' do
+    match = FactoryBot.build(:match)
+    expect(match).to be_valid
+  end
+
+  it 'is valid without a date' do
+    match = FactoryBot.build(:match, date: nil)
+
+    match.valid?
+    expect(match.errors[:date]).to include("can't be blank")
+  end
+
+  it 'is valid without a team_matches_index' do
+    match = FactoryBot.build(:match, team_matches_index: nil)
+
+    match.valid?
+    expect(match.errors[:team_matches_index]).to include("can't be blank")
+  end
+
+  it 'is valid without a season' do
+    match = FactoryBot.build(:match, season: nil)
+
+    match.valid?
+    expect(match.errors[:season]).to include("can't be blank")
+  end
+
+  it 'is valid without a competition_name' do
+    match = FactoryBot.build(:match, competition_name: nil)
+
+    match.valid?
+    expect(match.errors[:competition_name]).to include("can't be blank")
+  end
+
+  it 'is valid without a competition_logo' do
+    match = FactoryBot.build(:match, competition_logo: nil)
+
+    match.valid?
+    expect(match.errors[:competition_logo]).to include("can't be blank")
+  end
+
+  it 'is valid without a team_name' do
+    match = FactoryBot.build(:match, team_name: nil)
+
+    match.valid?
+    expect(match.errors[:team_name]).to include("can't be blank")
+  end
+
+  it 'is valid without a team_logo' do
+    match = FactoryBot.build(:match, team_logo: nil)
+
+    match.valid?
+    expect(match.errors[:team_logo]).to include("can't be blank")
+  end
+
+  it 'is valid without a home_and_away' do
+    match = FactoryBot.build(:match, home_and_away: nil)
+
+    match.valid?
+    expect(match.errors[:home_and_away]).to include("can't be blank")
+  end
+end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -3,9 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
+  before do
+    @team = Team.create(
+      id: 1,
+      name: 'Arsenal',
+      logo: 'https://media.api-sports.io/football/teams/42.png',
+      api_id: '42',
+      home_city: 'London',
+      league_id: 1
+    )
+  end
   it 'is valid with a name, logo, api_id and leaague_id and home_city' do
     league = FactoryBot.build(:league)
-    team = FactoryBot.build(:team, league: league)
+    team = FactoryBot.build(:team, :arsenal, league: league)
     expect(team).to be_valid
   end
 
@@ -18,7 +28,7 @@ RSpec.describe Team, type: :model do
 
   it 'is valid with a duplicate name' do
     league = FactoryBot.build(:league)
-    FactoryBot.create(:team, league: league)
+    FactoryBot.create(:team, :arsenal, league: league)
     team = Team.new(
       name: 'Arsenal',
       logo: 'https://media.api-sports.io/football/venues/494.png'
@@ -36,7 +46,7 @@ RSpec.describe Team, type: :model do
 
   it 'is valid with a duplicate logo' do
     league = FactoryBot.build(:league)
-    FactoryBot.create(:team, league: league)
+    FactoryBot.create(:team, :arsenal, league: league)
     team = Team.new(
       name: 'Manchester United',
       logo: 'https://media.api-sports.io/football/teams/42.png'
@@ -52,9 +62,9 @@ RSpec.describe Team, type: :model do
     expect(team.errors[:api_id]).to include("can't be blank")
   end
 
-  it 'is valid with a duplicate logo' do
+  it 'is valid with a duplicate api_id' do
     league = FactoryBot.build(:league)
-    FactoryBot.create(:team, league: league)
+    FactoryBot.create(:team, :arsenal, league: league)
     team = Team.new(
       name: 'Manchester United',
       logo: 'https://media.api-sports.io/football/teams/33.png',

--- a/spec/requests/api/favorite_team_matches_spec.rb
+++ b/spec/requests/api/favorite_team_matches_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::FavoriteTeamMatches', type: :request do
+  describe 'GET /api/favorite_team_matches/index' do
+    it 'returns http success' do
+      league = FactoryBot.create(:league)
+      team = FactoryBot.create(:team, league: league)
+      user = FactoryBot.build(:user)
+      sign_in user
+      user.favorite_team_follow(team)
+      get api_favorite_team_matches_path(format: :json)
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/api/first_competitor_team_matches_spec.rb
+++ b/spec/requests/api/first_competitor_team_matches_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::FirstCompetitorTeamMatches', type: :request do
+  describe 'GET /api/first_competitor_team_matches/index' do
+    it 'returns http success' do
+      league = FactoryBot.create(:league)
+      team = FactoryBot.create(:team, league: league)
+      user = FactoryBot.build(:user)
+      sign_in user
+      user.competitor_team_follow(team)
+      get api_first_competitor_team_matches_path(format: :json)
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/api/secound_competitor_team_matches_spec.rb
+++ b/spec/requests/api/secound_competitor_team_matches_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::SecoundCompetitorTeamMatches', type: :request do
+  describe 'GET /api/secound_competitor_team_matches/index' do
+    it 'returns http success' do
+      league = FactoryBot.create(:league)
+      team1 = FactoryBot.create(:team, league: league)
+      team2 = FactoryBot.create(:team, league: league)
+      user = FactoryBot.build(:user)
+      sign_in user
+      user.competitor_team_follow(team1)
+      user.competitor_team_follow(team2)
+      get api_secound_competitor_team_matches_path(format: :json)
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/api/third_competitor_team_matches_spec.rb
+++ b/spec/requests/api/third_competitor_team_matches_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::ThirdCompetitorTeamMatches', type: :request do
+  describe 'GET /api/third_competitor_team_matches/index' do
+    it 'returns http success' do
+      league = FactoryBot.create(:league)
+      team1 = FactoryBot.create(:team, league: league)
+      team2 = FactoryBot.create(:team, league: league)
+      team3 = FactoryBot.create(:team, league: league)
+      user = FactoryBot.build(:user)
+      sign_in user
+      user.competitor_team_follow(team1)
+      user.competitor_team_follow(team2)
+      user.competitor_team_follow(team3)
+      get api_third_competitor_team_matches_path(format: :json)
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
## 対応した issue
#74 
## 対応内容・対応背景・妥協点
試合予定が表示されるようにした

## UI before / after
### before
<img width="549" alt="Football" src="https://user-images.githubusercontent.com/62058863/163911739-092d5051-8019-46df-a6ec-6aba45348cbb.png">

### after
<img width="938" alt="Football" src="https://user-images.githubusercontent.com/62058863/163932792-2204298f-82e4-4b30-914a-526731be6063.png">


## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
