### PR TITLE
ヘッダーを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'net-smtp', require: false
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 gem 'devise'
+gem 'bulma-rails', '~> 0.9.3'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,8 @@ gem 'jbuilder', '~> 2.7'
 gem 'net-smtp', require: false
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
-gem 'devise'
 gem 'bulma-rails', '~> 0.9.3'
+gem 'devise'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
     bootsnap (1.11.1)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bulma-rails (0.9.3)
+      sassc (~> 2.0)
     byebug (11.1.3)
     capybara (3.36.0)
       addressable
@@ -309,6 +311,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bulma-rails (~> 0.9.3)
   byebug
   capybara (>= 3.26)
   devise

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
+@import "bulma"
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.

--- a/app/javascript/components/page/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="has-text-centered">
+  <div class="has-text-centered pt-5">
     <div v-show="data.isShowing">
       <div class="container is-widescreen">
         <div class="notification is-light">
@@ -69,7 +69,7 @@
         <router-link to="/">応援しているチームを選び直す</router-link>
       </button>
       <button class="button mt-2 ml-2" @click="addCompetitorFollow">
-        上記のチームを登録する
+        <router-link to="/schedules">上記のチームを登録する</router-link>
       </button>
       <button class="button mt-2 ml-2" @click="again">
         チームの選び方を変更する

--- a/app/javascript/components/page/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container pt-5">
     <table class="table">
       <thead>
         <tr>

--- a/app/javascript/components/page/TeamScheduleShowPage.vue
+++ b/app/javascript/components/page/TeamScheduleShowPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container pt-5">
     <div class="tabs is-toggle is-centered">
       <ul>
         <li v-bind:class="{ 'is-active': data.isActive == 'match_schedule' }">

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,15 +9,21 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
-    header
-      nav
-        - if user_signed_in?
-          = link_to current_user.email, root_path
-          = link_to 'プロフィール変更', edit_user_registration_path
-          = link_to 'ログアウト', destroy_user_session_path, method: :delete
-        - else
-          = link_to '新規登録', new_user_registration_path
-          = link_to 'ログイン', new_user_session_path
+    header.p-6
+      .navbar.is-link.is-transparent.is-fixed-top.p-5
+        .navbar-brand
+          .navbar-item
+            .title
+              = link_to 'Football Calendar', root_path, class: 'has-text-white'
+        .navbar-menu
+          .navbar-end
+            .navbar-item
+              - if user_signed_in?
+                  = link_to 'プロフィール変更', edit_user_registration_path, class: 'has-text-white mx-2'
+                  = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'has-text-white mx-2'
+              - else
+                  = link_to '新規登録', new_user_registration_path, class: 'has-text-white'
+                  = link_to 'ログイン', new_user_session_path, class: 'has-text-white'
     p
       .notice
         = notice


### PR DESCRIPTION
## 対応した issue
#26 
## 対応内容・対応背景・妥協点
- ヘッダーを作成した
## やったこと
- アプリ名をクリックすることでホーム画面に戻れるようにした
- ヘッダーのリンクから、「ユーザー情報変更」と「ログアウト」をできるようにした
- ヘッダーを固定した

## やってないこと
- ユーザー情報変更ページ
- ログアウト後の遷移
## UI before / after
### before

<img width="1293" alt="Football_と_Comparing_main___feature_add-header_·_R-Tsukada_football-calendar" src="https://user-images.githubusercontent.com/62058863/165423887-3759ce3f-45bf-4587-a1e7-8e285aca636e.png">

### after
<img width="1138" alt="Football" src="https://user-images.githubusercontent.com/62058863/165423431-f5945906-b66b-4b94-a190-2f10f386995f.png">

#### ヘッダーを固定
[![Image from Gyazo](https://i.gyazo.com/c3954a742b009da9d7d861eac9a39351.gif)](https://gyazo.com/c3954a742b009da9d7d861eac9a39351)

#### ユーザー情報変更
[![Image from Gyazo](https://i.gyazo.com/48721251ea428074e4b968b146801b73.gif)](https://gyazo.com/48721251ea428074e4b968b146801b73)

#### ログアウト
[![Image from Gyazo](https://i.gyazo.com/fc6cc4e503d00c75fe5b9e32900c0f5c.gif)](https://gyazo.com/fc6cc4e503d00c75fe5b9e32900c0f5c)

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
