### PR TITLE
webpack-dev-serverを起動できるようにした

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - .:/football
     environment:
-      - WEBPACKER_DEV_SERVER_HOST=webpacker
+      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## 対応した issue
#86 
## 対応内容・対応背景・妥協点

## やったこと
- `docker-compose.yml`の設定を変更
## UI before / after
なし
## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
