### PR TITLE
404ページを作成

### DIFF
--- a/app/javascript/components/request_error/NotFound.vue
+++ b/app/javascript/components/request_error/NotFound.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class='container'>
+    <div class='box'>
+      <h1 class='is-size-1 has-text-centered has-text-weight-bold'>
+        404
+      </h1>
+      <h2 class='is-size-3 has-text-centered py-2'>
+        お探しのページが見つかりませんでした
+      </h2>
+      <p class='py-2'>ご指定のページは削除されたか、移動した可能性があります</p>
+    </div>
+    <button class='button is-rounded is-medium mx-auto'>
+      <router-link to='/schedules'>日程一覧に戻る</router-link>
+    </button>
+  </div>
+</template>

--- a/app/javascript/components/request_error/NotFound.vue
+++ b/app/javascript/components/request_error/NotFound.vue
@@ -1,16 +1,14 @@
 <template>
-  <div class='container'>
-    <div class='box'>
-      <h1 class='is-size-1 has-text-centered has-text-weight-bold'>
-        404
-      </h1>
-      <h2 class='is-size-3 has-text-centered py-2'>
+  <div class="container">
+    <div class="box">
+      <h1 class="is-size-1 has-text-centered has-text-weight-bold">404</h1>
+      <h2 class="is-size-3 has-text-centered py-2">
         お探しのページが見つかりませんでした
       </h2>
-      <p class='py-2'>ご指定のページは削除されたか、移動した可能性があります</p>
+      <p class="py-2">ご指定のページは削除されたか、移動した可能性があります</p>
     </div>
-    <button class='button is-rounded is-medium mx-auto'>
-      <router-link to='/schedules'>日程一覧に戻る</router-link>
+    <button class="button is-rounded is-medium mx-auto">
+      <router-link to="/schedules">日程一覧に戻る</router-link>
     </button>
   </div>
 </template>

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -3,6 +3,7 @@ import TeamList from '../components/page/TeamSelect.vue'
 import CompetitorTeamSelect from '../components/page/CompetitorTeamSelect.vue'
 import TeamSchedule from '../components/page/TeamSchedule.vue'
 import TeamScheduleShowPage from '../components/page/TeamScheduleShowPage.vue'
+import NotFound from '../components/request_error/NotFound.vue'
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -23,6 +24,10 @@ export const router = createRouter({
       path: '/schedules/:id',
       name: 'show',
       component: TeamScheduleShowPage
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      component: NotFound
     }
   ]
 })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  root to: 'home#index'
-  get 'privacy_policy', to: 'home#privacy_policy', as: 'privacy_policy'
-  get 'terms_of_service', to: 'home#terms_of_service', as: 'terms_of_service'
   devise_for :users
   get 'leagues', to: 'leagues#index', as: 'leagues'
+  root to: 'home#index'
   namespace :api, format: 'json' do
     resources :leagues, only: [:index]
     resources :teams, only: [:index]
@@ -18,4 +16,8 @@ Rails.application.routes.draw do
     resources :secound_competitor_team_matches, only: [:index]
     resources :third_competitor_team_matches, only: [:index]
   end
+  resources :home, only: %i(index)
+  get 'privacy_policy', to: 'home#privacy_policy', as: 'privacy_policy'
+  get 'terms_of_service', to: 'home#terms_of_service', as: 'terms_of_service'
+  get '*path', to: 'leagues#index'
 end

--- a/spec/system/not_found_spec.rb
+++ b/spec/system/not_found_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'NotFoundPage', type: :system, js: true do
+  it 'display 404 page', js: true do
+    user = FactoryBot.create(:user)
+
+    visit root_path
+    all('.button')[1].click_link 'ログイン'
+    fill_in 'Eメール', with: user.email
+    fill_in 'パスワード', with: user.password
+    click_button 'ログイン'
+
+    visit '/rails'
+    expect(page).to have_content "404\nお探しのページが見つかりませんでした"
+  end
+end


### PR DESCRIPTION
## 対応した issue
#88 
## 対応内容・対応背景・妥協点
404ページを作成
## やったこと
- 404ページを作成
- Railsの`routes.rb`を修正
- vue-routerに404ページを追加
- 日程表示ページに戻るボタンを追加
## やってないこと
- トップページに戻るボタンは追加していない。
トップページをVueファイルに変更した後にボタンを追加する。
## UI before / after
<img width="1730" alt="Football" src="https://user-images.githubusercontent.com/62058863/166473111-a7466469-55f9-4a3b-8946-307d2a10b457.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
