### PR TITLE
ライバルチームの登録が3チーム以下だった場合にエラーが出る問題を修正

### DIFF
--- a/app/controllers/api/secound_competitor_team_matches_controller.rb
+++ b/app/controllers/api/secound_competitor_team_matches_controller.rb
@@ -5,6 +5,10 @@ class Api::SecoundCompetitorTeamMatchesController < ApplicationController
     user = current_user
     competitor_teams = user.competitor.map(&:team_id)
     current_team = Team.find(competitor_teams[1]).api_id
-    @secound_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
+    if competitor_teams.length >= 2
+      @secound_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
+    else
+      return render json: { message: 'error' }, status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/api/secound_competitor_team_matches_controller.rb
+++ b/app/controllers/api/secound_competitor_team_matches_controller.rb
@@ -8,7 +8,7 @@ class Api::SecoundCompetitorTeamMatchesController < ApplicationController
     if competitor_teams.length >= 2
       @secound_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
     else
-      return render json: { message: 'error' }, status: :unprocessable_entity
+      render json: { message: 'error' }, status: :unprocessable_entity
     end
   end
 end

--- a/app/controllers/api/third_competitor_team_matches_controller.rb
+++ b/app/controllers/api/third_competitor_team_matches_controller.rb
@@ -4,7 +4,11 @@ class Api::ThirdCompetitorTeamMatchesController < ApplicationController
   def index
     user = current_user
     competitor_teams = user.competitor.map(&:team_id)
-    current_team = Team.find(competitor_teams[2]).api_id
-    @third_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
+    if competitor_teams.length == 3
+      current_team = Team.find(competitor_teams[2]).api_id
+      @third_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
+    else
+      return render json: { message: 'error' }, status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/api/third_competitor_team_matches_controller.rb
+++ b/app/controllers/api/third_competitor_team_matches_controller.rb
@@ -8,7 +8,7 @@ class Api::ThirdCompetitorTeamMatchesController < ApplicationController
       current_team = Team.find(competitor_teams[2]).api_id
       @third_competitor_team_matches = Match.all.order(:date).where(date: Time.zone.today.., team_matches_index: current_team).first(3)
     else
-      return render json: { message: 'error' }, status: :unprocessable_entity
+      render json: { message: 'error' }, status: :unprocessable_entity
     end
   end
 end

--- a/app/javascript/components/page/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule.vue
@@ -59,7 +59,8 @@ export default {
     })
 
     const setTeamSchedules = async () => {
-      axios.get('/api/standings')
+      axios
+        .get('/api/standings')
         .then((response) => {
           data.favoriteTeams = response.data[0]
           data.firstCompetitorTeams = response.data[1]
@@ -72,7 +73,8 @@ export default {
     }
 
     const setMatchSchedules = async () => {
-      axios.get('/api/favorite_team_matches')
+      axios
+        .get('/api/favorite_team_matches')
         .then((response) => {
           data.favoriteMatchSchedules = response.data
         })
@@ -82,7 +84,8 @@ export default {
     }
 
     const setFirstCompetitorMatchSchedules = async () => {
-      axios.get('/api/first_competitor_team_matches')
+      axios
+        .get('/api/first_competitor_team_matches')
         .then((response) => {
           data.firstCompetitorMatchSchedules = response.data
         })
@@ -92,7 +95,8 @@ export default {
     }
 
     const setSecoundCompetitorMatchSchedules = async () => {
-      axios.get('/api/secound_competitor_team_matches')
+      axios
+        .get('/api/secound_competitor_team_matches')
         .then((response) => {
           data.secoundCompetitorMatchSchedules = response.data
         })
@@ -102,7 +106,8 @@ export default {
     }
 
     const setThirdCompetitorMatchSchedules = async () => {
-      axios.get('/api/third_competitor_team_matches')
+      axios
+        .get('/api/third_competitor_team_matches')
         .then((response) => {
           data.thirdCompetitorMatchSchedules = response.data
         })

--- a/app/javascript/components/page/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule.vue
@@ -19,9 +19,11 @@
         :standings="data.firstCompetitorTeams"
         :matchSchedules="data.firstCompetitorMatchSchedules" />
       <FavoriteTeamTable
+        v-if="data.secoundCompetitorTeams"
         :standings="data.secoundCompetitorTeams"
         :matchSchedules="data.secoundCompetitorMatchSchedules" />
       <FavoriteTeamTable
+        v-if="data.thirdCompetitorTeams"
         :standings="data.thirdCompetitorTeams"
         :matchSchedules="data.thirdCompetitorMatchSchedules" />
     </table>
@@ -57,36 +59,56 @@ export default {
     })
 
     const setTeamSchedules = async () => {
-      axios.get('/api/standings').then((response) => {
-        data.favoriteTeams = response.data[0]
-        data.firstCompetitorTeams = response.data[1]
-        data.secoundCompetitorTeams = response.data[2]
-        data.thirdCompetitorTeams = response.data[3]
-      })
+      axios.get('/api/standings')
+        .then((response) => {
+          data.favoriteTeams = response.data[0]
+          data.firstCompetitorTeams = response.data[1]
+          data.secoundCompetitorTeams = response.data[2]
+          data.thirdCompetitorTeams = response.data[3]
+        })
+        .catch((error) => {
+          console.log(error.message)
+        })
     }
 
     const setMatchSchedules = async () => {
-      axios.get('/api/favorite_team_matches').then((response) => {
-        data.favoriteMatchSchedules = response.data
-      })
+      axios.get('/api/favorite_team_matches')
+        .then((response) => {
+          data.favoriteMatchSchedules = response.data
+        })
+        .catch((error) => {
+          console.log(error.message)
+        })
     }
 
     const setFirstCompetitorMatchSchedules = async () => {
-      axios.get('/api/first_competitor_team_matches').then((response) => {
-        data.firstCompetitorMatchSchedules = response.data
-      })
+      axios.get('/api/first_competitor_team_matches')
+        .then((response) => {
+          data.firstCompetitorMatchSchedules = response.data
+        })
+        .catch((error) => {
+          console.log(error.message)
+        })
     }
 
     const setSecoundCompetitorMatchSchedules = async () => {
-      axios.get('/api/secound_competitor_team_matches').then((response) => {
-        data.secoundCompetitorMatchSchedules = response.data
-      })
+      axios.get('/api/secound_competitor_team_matches')
+        .then((response) => {
+          data.secoundCompetitorMatchSchedules = response.data
+        })
+        .catch((error) => {
+          console.log(error.message)
+        })
     }
 
     const setThirdCompetitorMatchSchedules = async () => {
-      axios.get('/api/third_competitor_team_matches').then((response) => {
-        data.thirdCompetitorMatchSchedules = response.data
-      })
+      axios.get('/api/third_competitor_team_matches')
+        .then((response) => {
+          data.thirdCompetitorMatchSchedules = response.data
+        })
+        .catch((error) => {
+          console.log(error.message)
+        })
     }
 
     onMounted(() => {

--- a/app/javascript/components/page/TeamScheduleShowPage.vue
+++ b/app/javascript/components/page/TeamScheduleShowPage.vue
@@ -64,7 +64,7 @@ export default {
     const formatDate = (date) => {
       const yyyy = String(date.getFullYear())
       const mm = String(date.getMonth() + 1).padStart(2, '0')
-      const dd = String(date.getDate()).padStart(2, '1')
+      const dd = String(date.getDate()).padStart(2, '0')
       return `${yyyy}-${mm}-${dd}`
     }
 


### PR DESCRIPTION
## 対応した issue
#96 
## 対応内容・対応背景・妥協点
### 対応内容
- ライバルチームの登録が3チーム以下だとエラーが発生していた
- ライバルチームの登録数に関係なく、3チーム分の情報を取得しようとしていたことが原因
### 妥協点
- 登録数が3チーム以下だと422が返ってくる
- 今後コントローラーを一つにして、422が返ってこない仕様にする必要あり
## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
