### PR TITLE
ライバルチームを選択するときのバリデーションを追加

### DIFF
--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -69,7 +69,9 @@
         </ul>
       </div>
       <br />
-      <button class="button is-rounded is-medium mt-2 ml-2" @click="addCompetitorFollow">
+      <button
+        class="button is-rounded is-medium mt-2 ml-2"
+        @click="addCompetitorFollow">
         <router-link to="/schedules">上記のチームを登録する</router-link>
       </button>
       <button class="button is-rounded is-medium mt-2 ml-2" @click="again">
@@ -97,10 +99,16 @@
       <button class="button is-rounded is-medium mt-2 ml-2">
         <router-link to="/">応援しているチームを選び直す</router-link>
       </button>
-      <button class="button is-rounded is-medium mt-2 ml-2" @click="again">ライバルチームの選択方法を選び直す</button>
+      <button class="button is-rounded is-medium mt-2 ml-2" @click="again">
+        ライバルチームの選択方法を選び直す
+      </button>
       <br />
-      <button class="button is-rounded is-medium mt-2 ml-2" v-if="this.$store.state.competitorTeamId.length >= 1">
-        <router-link to="/schedules">ライバルチームの選択を終了する</router-link>
+      <button
+        class="button is-rounded is-medium mt-2 ml-2"
+        v-if="this.$store.state.competitorTeamId.length >= 1">
+        <router-link to="/schedules"
+          >ライバルチームの選択を終了する</router-link
+        >
       </button>
     </div>
   </div>
@@ -204,7 +212,7 @@ export default {
         data.isShowing = false
         data.isAdding = true
         data.isSelected = false
-      } else if (data.checkedName === ''){
+      } else if (data.checkedName === '') {
         data.isSelected = true
       } else {
         data.isShowing = false

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -90,13 +90,14 @@
         </ul>
       </div>
       <br />
-      <button class="button mt-2 ml-2">
+      <button class="button is-rounded is-medium mt-2 ml-2">
         <router-link to="/">応援しているチームを選び直す</router-link>
       </button>
-      <button class="button mt-2 ml-2" v-if="this.$store.state.competitorTeamId.length >= 1">
-        <router-link to="/schedules">チームの選択を終了する</router-link>
+      <button class="button is-rounded is-medium mt-2 ml-2" @click="again">ライバルチームの選択方法を選び直す</button>
+      <br />
+      <button class="button is-rounded is-medium mt-2 ml-2" v-if="this.$store.state.competitorTeamId.length >= 1">
+        <router-link to="/schedules">ライバルチームの選択を終了する</router-link>
       </button>
-      <button class="button mt-2 ml-2" @click="again">もう一度選び直す</button>
     </div>
   </div>
 </template>

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -93,7 +93,7 @@
       <button class="button mt-2 ml-2">
         <router-link to="/">応援しているチームを選び直す</router-link>
       </button>
-      <button class="button mt-2 ml-2">
+      <button class="button mt-2 ml-2" v-if="this.$store.state.competitorTeamId.length >= 1">
         <router-link to="/schedules">チームの選択を終了する</router-link>
       </button>
       <button class="button mt-2 ml-2" @click="again">もう一度選び直す</button>
@@ -105,8 +105,8 @@
 import axios from 'axios'
 import { reactive, onMounted } from 'vue'
 import { useStore } from 'vuex'
-import CompetitorValidation from '../modal/CompetitorValidation.vue'
-import CompetitorTeamSelect from '../modal/CompetitorTeamCount.vue'
+import CompetitorValidation from '../../modal/CompetitorValidation.vue'
+import CompetitorTeamSelect from '../../modal/CompetitorTeamCount.vue'
 export default {
   components: {
     CompetitorValidation,

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -40,10 +40,10 @@
           </div>
         </div>
       </div>
-      <button class="button mt-4 ml-3" @click="selectTeam">
+      <button class="button is-rounded is-medium mt-4 ml-3" @click="selectTeam">
         チームの選択方法を決定する
       </button>
-      <button class="button mt-4 ml-3">
+      <button class="button is-rounded is-medium mt-4 ml-3">
         <router-link to="/leagues">応援しているチームを選び直す</router-link>
       </button>
     </div>
@@ -65,14 +65,14 @@
         </ul>
       </div>
       <br />
-      <button class="button mt-2 ml-3">
-        <router-link to="/">応援しているチームを選び直す</router-link>
-      </button>
-      <button class="button mt-2 ml-2" @click="addCompetitorFollow">
+      <button class="button is-rounded is-medium mt-2 ml-2" @click="addCompetitorFollow">
         <router-link to="/schedules">上記のチームを登録する</router-link>
       </button>
-      <button class="button mt-2 ml-2" @click="again">
+      <button class="button is-rounded is-medium mt-2 ml-2" @click="again">
         チームの選び方を変更する
+      </button>
+      <button class="button is-rounded is-medium mt-2 ml-3">
+        <router-link to="/">応援しているチームを選び直す</router-link>
       </button>
     </div>
     <div v-show="data.isFreeSelect">

--- a/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
+++ b/app/javascript/components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="has-text-centered pt-5">
+    <div class="notification is-danger is-size-4" v-show="data.isSelected">
+      <button class="delete" @click="deleteMessage"></button>
+      ライバルチームの選択方法を最低でも一つ選んでください
+    </div>
     <div v-show="data.isShowing">
       <div class="container is-widescreen">
         <div class="notification is-light">
@@ -122,7 +126,8 @@ export default {
       selectedTeams: [],
       isShowing: true,
       isAdding: false,
-      isFreeSelect: false
+      isFreeSelect: false,
+      isSelected: false
     })
 
     const store = useStore()
@@ -182,12 +187,13 @@ export default {
     }
 
     const autoSelect = () => {
-      data.isShowing = false
       if (data.checkedName === 'home') {
         data.selectedTeams = data.teams.filter(
           (teams) => teams.home_city === data.favorite.team.home_city
         )
+        data.isShowing = false
         data.isAdding = true
+        data.isSelected = false
       } else if (data.checkedName === 'rank') {
         data.selectedTeams = data.teams.filter(
           (teams) =>
@@ -195,10 +201,20 @@ export default {
               data.favorite.team.last_season_rank - 1 ||
             teams.last_season_rank === data.favorite.team.last_season_rank + 1
         )
+        data.isShowing = false
         data.isAdding = true
+        data.isSelected = false
+      } else if (data.checkedName === ''){
+        data.isSelected = true
       } else {
+        data.isShowing = false
         data.isFreeSelect = true
+        data.isSelected = false
       }
+    }
+
+    const deleteMessage = () => {
+      data.isSelected = false
     }
 
     const again = () => {
@@ -236,7 +252,8 @@ export default {
       autoSelect,
       selectTeam,
       again,
-      addCompetitorFollow
+      addCompetitorFollow,
+      deleteMessage
     }
   }
 }

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -48,8 +48,8 @@
 <script>
 import axios from 'axios'
 import { reactive, onMounted } from 'vue'
-import FavoriteTeamTable from '../table/FavoriteTeamTable.vue'
-import CompetitorTeamTable from '../table/CompetitorTeamTable.vue'
+import FavoriteTeamTable from '../../table/FavoriteTeamTable.vue'
+import CompetitorTeamTable from '../../table/CompetitorTeamTable.vue'
 
 export default {
   components: {

--- a/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamScheduleShowPage.vue
@@ -32,8 +32,8 @@
 import axios from 'axios'
 import { reactive, onMounted, computed } from 'vue'
 import { useStore } from 'vuex'
-import MatchScheduleList from '../list/MatchScheduleList.vue'
-import MatchResultList from '../list/MatchResultList.vue'
+import MatchScheduleList from '../../list/MatchScheduleList.vue'
+import MatchResultList from '../../list/MatchResultList.vue'
 
 export default {
   components: {

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -1,8 +1,8 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import TeamList from '../components/page/TeamSelect.vue'
-import CompetitorTeamSelect from '../components/page/CompetitorTeamSelect.vue'
-import TeamSchedule from '../components/page/TeamSchedule.vue'
-import TeamScheduleShowPage from '../components/page/TeamScheduleShowPage.vue'
+import CompetitorTeamSelect from '../components/page/CompetitorTeamSelect/CompetitorTeamSelect.vue'
+import TeamSchedule from '../components/page/TeamSchedule/TeamSchedule.vue'
+import TeamScheduleShowPage from '../components/page/TeamSchedule/TeamScheduleShowPage.vue'
 import NotFound from '../components/request_error/NotFound.vue'
 
 export const router = createRouter({


### PR DESCRIPTION
## 対応した issue
#102 
## 対応内容・対応背景・妥協点
- ライバルチーム選択のバリデーションを追加
- CompetitorTeamSelect.vueのコンポーネント化ができていない

## やったこと
- ライバルチーム選択方法のバリデーション
- ライバルチーム選択のバリデーション
## やってないこと
レイアウト
## UI before / after
### before
[![Image from Gyazo](https://i.gyazo.com/83cd5936d16a746fac80e0027aed215a.gif)](https://gyazo.com/83cd5936d16a746fac80e0027aed215a)

[![Image from Gyazo](https://i.gyazo.com/592745cba59ae3dacd3e44958911503c.gif)](https://gyazo.com/592745cba59ae3dacd3e44958911503c)

### after
<img width="1733" alt="Football" src="https://user-images.githubusercontent.com/62058863/167243193-a3b13771-ba75-42b4-b65b-2205a4af97d4.png">

<img width="1726" alt="Football" src="https://user-images.githubusercontent.com/62058863/167243197-e8044a4c-8c5b-4cd7-b38a-c11b88cc4e62.png">

<img width="1732" alt="Football" src="https://user-images.githubusercontent.com/62058863/167243206-871da840-289c-41e0-84fb-8c15dcfd1162.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
