### PR TITLE
チーム変更するためのリンクをヘッダーに追加

### DIFF
--- a/app/controllers/api/favorites_controller.rb
+++ b/app/controllers/api/favorites_controller.rb
@@ -4,13 +4,12 @@ class Api::FavoritesController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   before_action :authenticate_user!
+  before_action :set_favorite_team, only: %i[index]
   before_action :set_follow, only: %i[create]
 
   def index
     user = current_user
-    id = user.favorite.team_id
-    team = Team.find(id)
-    @favorite_team = team
+    @favorite_team = user.favorite.present? ? @team : @not_team
   end
 
   def create
@@ -19,6 +18,16 @@ class Api::FavoritesController < ApplicationController
   end
 
   private
+
+  def set_favorite_team
+    user = current_user
+    if user.favorite.present?
+      id = user.favorite.team_id
+      @team = Team.find(id)
+    else
+      @not_team = []
+    end
+  end
 
   def set_follow
     id = params.require(:favorite).permit(:id)

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -33,16 +33,6 @@
       </tbody>
     </table>
     <br />
-    <button class="button is-link is-rounded m-3 is-medium">
-      <router-link to="/leagues" class="has-text-white"
-        >応援しているチームを選び直す</router-link
-      >
-    </button>
-    <button class="button is-rounded m-3 is-medium has-text-black">
-      <router-link to="/competitors" class="has-text-black"
-        >ライバルチームを選び直す</router-link
-      >
-    </button>
   </div>
 </template>
 <script>

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="has-text-centered">
     <div v-if="data.isChangeColorTeam.length === 0">
-      <p class="is-size-4 has-text-weight-bold mt-5">あなたが応援しているチームを選びます。そのあとに同じリーグの中からライバルチームを選びます。</p>
-      <p class="is-size-4 has-text-weight-bold my-5">まずは応援しているチームが所属しているチームを選んでください</p>
+      <p class="is-size-4 has-text-weight-bold mt-5">
+        あなたが応援しているチームを選びます。そのあとに同じリーグの中からライバルチームを選びます。
+      </p>
+      <p class="is-size-4 has-text-weight-bold my-5">
+        まずは応援しているチームが所属しているチームを選んでください
+      </p>
     </div>
     <div v-else class="has-text-right mr-5 mb-5 is-size-5 has-text-weight-bold">
-        <router-link to="/competitors">
-          ライバルチームのみ変更する
-        </router-link>
+      <router-link to="/competitors"> ライバルチームのみ変更する </router-link>
     </div>
     <div class="container">
       <ul v-for="league in data.leagues" :key="league.id">
@@ -50,7 +52,9 @@
       </ul>
     </div>
     <div v-if="data.isChangeColorTeam">
-      <button class="button is-link is-rounded m-3 is-medium mt-5" @click="addFavoriteTeam">
+      <button
+        class="button is-link is-rounded m-3 is-medium mt-5"
+        @click="addFavoriteTeam">
         <router-link to="/competitors" class="has-text-white"
           >応援しているチームを決定する</router-link
         >

--- a/app/javascript/components/page/TeamSelect.vue
+++ b/app/javascript/components/page/TeamSelect.vue
@@ -1,5 +1,14 @@
 <template>
   <div class="has-text-centered">
+    <div v-if="data.isChangeColorTeam.length === 0">
+      <p class="is-size-4 has-text-weight-bold mt-5">あなたが応援しているチームを選びます。そのあとに同じリーグの中からライバルチームを選びます。</p>
+      <p class="is-size-4 has-text-weight-bold my-5">まずは応援しているチームが所属しているチームを選んでください</p>
+    </div>
+    <div v-else class="has-text-right mr-5 mb-5 is-size-5 has-text-weight-bold">
+        <router-link to="/competitors">
+          ライバルチームのみ変更する
+        </router-link>
+    </div>
     <div class="container">
       <ul v-for="league in data.leagues" :key="league.id">
         <li
@@ -41,8 +50,8 @@
       </ul>
     </div>
     <div v-if="data.isChangeColorTeam">
-      <button class="button mt-5" @click="addFavoriteTeam">
-        <router-link to="/competitors"
+      <button class="button is-link is-rounded m-3 is-medium mt-5" @click="addFavoriteTeam">
+        <router-link to="/competitors" class="has-text-white"
           >応援しているチームを決定する</router-link
         >
       </button>
@@ -113,7 +122,7 @@ export default {
         : (data.isChangeColorTeam = team.id)
     }
 
-    onMounted(setLeague(), setTeam())
+    onMounted(setLeague(), setTeam(), setFavorite())
 
     return {
       data,
@@ -135,11 +144,11 @@ export default {
   justify-content: center;
 }
 
-ul {
+.container ul {
   list-style: none;
 }
 
-li {
+.container li {
   border: solid 1px;
 }
 </style>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,5 +11,5 @@ import 'channels'
 require('../main.js')
 
 Rails.start()
-Turbolinks.start()
+Turbolinks.load()
 ActiveStorage.start()

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -3,14 +3,14 @@
     = t('.edit')
   = form_with model: @user, url: user_registration_path, html: { method: :put } do |f|
     = render 'devise/shared/error_messages', resource: resource
-    .field.has-text-left.has-text-weight-semibold.my-4
-      = f.label :email
-      = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
-      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-        div
-          | Currently waiting confirmation for:
-          = resource.unconfirmed_email
     .container
+      .field.has-text-left.has-text-weight-semibold.my-4
+        = f.label :email
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'
+        - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+          div
+            | Currently waiting confirmation for:
+            = resource.unconfirmed_email
       .field
         .container.has-text-left.has-text-weight-semibold.my-4
           = f.label :current_password

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -19,6 +19,7 @@ html
           .navbar-end
             .navbar-item
               - if user_signed_in?
+                = link_to '登録しているチームを変更する', '/leagues', class: 'has-text-white mx-2'
                 = link_to 'プロフィール変更', edit_user_registration_path, class: 'has-text-white mx-2'
                 = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'has-text-white mx-2'
               - else

--- a/spec/system/signin_and_signup_spec.rb
+++ b/spec/system/signin_and_signup_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe 'devise', type: :system, js: true do
   let(:user) { FactoryBot.create(:user) }
   let(:league) { FactoryBot.create(:league) }
 
-  it 'user can login', js: true do
-    team1 = FactoryBot.create(:team, :arsenal, league: league)
-    team2 = FactoryBot.create(:team, :Manchester_United, league: league)
-    FactoryBot.create(:favorite, user: user, team: team1)
-    FactoryBot.create(:competitor, user: user, team: team2)
-
-    visit root_path
-    all('.button')[1].click_link 'ログイン'
-    fill_in 'Eメール', with: user.email
-    fill_in 'パスワード', with: user.password
-    click_button 'ログイン'
-
-    expect(page).to have_content 'ログインしました'
-  end
+  # it 'user can login', js: true do
+  #   team1 = FactoryBot.create(:team, :arsenal, league: league)
+  #   team2 = FactoryBot.create(:team, :Manchester_United, league: league)
+  #   FactoryBot.create(:favorite, user: user, team: team1)
+  #   FactoryBot.create(:competitor, user: user, team: team2)
+  #
+  #   visit root_path
+  #   all('.button')[1].click_link 'ログイン'
+  #   fill_in 'Eメール', with: user.email
+  #   fill_in 'パスワード', with: user.password
+  #   click_button 'ログイン'
+  #
+  #   expect(page).to have_content 'ログインしました'
+  # end
 
   it 'email error when login.', js: true do
     visit root_path

--- a/spec/system/signin_and_signup_spec.rb
+++ b/spec/system/signin_and_signup_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe 'devise', type: :system, js: true do
   let(:user) { FactoryBot.create(:user) }
   let(:league) { FactoryBot.create(:league) }
 
-  # it 'user can login', js: true do
-  #   team1 = FactoryBot.create(:team, :arsenal, league: league)
-  #   team2 = FactoryBot.create(:team, :Manchester_United, league: league)
-  #   FactoryBot.create(:favorite, user: user, team: team1)
-  #   FactoryBot.create(:competitor, user: user, team: team2)
-  #
-  #   visit root_path
-  #   all('.button')[1].click_link 'ログイン'
-  #   fill_in 'Eメール', with: user.email
-  #   fill_in 'パスワード', with: user.password
-  #   click_button 'ログイン'
-  #
-  #   expect(page).to have_content 'ログインしました'
-  # end
+  it 'user can login', js: true do
+    team1 = FactoryBot.create(:team, :arsenal, league: league)
+    team2 = FactoryBot.create(:team, :Manchester_United, league: league)
+    FactoryBot.create(:favorite, user: user, team: team1)
+    FactoryBot.create(:competitor, user: user, team: team2)
+
+    visit root_path
+    all('.button')[1].click_link 'ログイン'
+    fill_in 'Eメール', with: user.email
+    fill_in 'パスワード', with: user.password
+    click_button 'ログイン'
+
+    expect(page).to have_content 'ログインしました'
+  end
 
   it 'email error when login.', js: true do
     visit root_path
@@ -50,6 +50,7 @@ RSpec.describe 'devise', type: :system, js: true do
     click_button 'アカウント登録'
 
     expect(page).to have_content 'アカウント登録が完了しました'
+    expect(page).not_to have_content 'ライバルチームのみを変更する'
   end
 
   it 'password validation enabled during account creation', js: true do


### PR DESCRIPTION
## 対応した issue
#109 
## 対応内容・対応背景・妥協点
- ヘッダーにチーム変更のリンクを追加
- 応援しているチームを選択するページに説明文を追加
## やったこと
- ヘッダーにリンクを追加
- チーム変更のボタンを削除
- テストを修正

## UI before / after
### before
<img width="1424" alt="Football" src="https://user-images.githubusercontent.com/62058863/167431721-e303fdb8-2e87-4007-b3b6-4a6eb436995c.png">

<img width="1376" alt="Football" src="https://user-images.githubusercontent.com/62058863/167431751-86487437-264a-4d31-a87c-ca61509dbf94.png">

### after
<img width="1421" alt="Football" src="https://user-images.githubusercontent.com/62058863/167424972-61939ff4-66b0-41a1-83f8-426ca244565c.png">

<img width="1424" alt="Football" src="https://user-images.githubusercontent.com/62058863/167431144-1702657b-22ea-4923-af8a-3c55a202dc97.png">



<img width="1425" alt="Football" src="https://user-images.githubusercontent.com/62058863/167425010-99304656-3ca7-4371-92f3-1173f88c5c32.png">


## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
