### PR TITLE
Feature/messeage display end of season

### DIFF
--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -1,9 +1,30 @@
 <template>
   <div class="container">
-    <h2 class="is-size-2 has-text-centered has-text-weight-bold pb-6">
+    <h2
+      v-if="'2022-05-28' > formatDate(date) || '2022-07-05' < formatDate(date)"
+      class="is-size-2 has-text-centered has-text-weight-bold pb-6">
       リーグ戦情報
     </h2>
-    <MatchListLoader v-if="!data.matches.length" />
+    <h2
+      v-else
+      class="is-size-2 has-text-centered has-text-weight-bold pb-6 has-text-danger">
+      20-21シーズンは終了しました
+    </h2>
+    <div class="box" v-if="'2022-05-28' < formatDate(date)">
+      <p class="has-text-centered is-size-3 has-text-weight-bold">
+        ⚽️21-22シーズンの開幕予定🥅
+      </p>
+      <div class="mx-auto has-text-centered mt-3">
+        <ul class="is-size-5 has-text-weight-bold p-2">
+          <li>プレミア：8月 6日(土)</li>
+          <li>ラリーガ：8月12日(金)</li>
+          <li>ブンデス：8月 5日(金)</li>
+          <li>セリエA：未定</li>
+        </ul>
+      </div>
+    </div>
+    <MatchListLoader
+      v-else-if="'2022-05-28' > formatDate(date) && !data.matches.length" />
     <table
       v-else
       class="table is-stripe is-hoverable is-clickable has-text-centered has-text-weight-bold is-size-5">
@@ -131,6 +152,15 @@ export default {
       )
     )
 
+    const date = new Date()
+
+    const formatDate = (date) => {
+      const yyyy = String(date.getFullYear())
+      const mm = String(date.getMonth() + 1).padStart(2, '0')
+      const dd = String(date.getDate()).padStart(2, '0')
+      return `${yyyy}-${mm}-${dd}`
+    }
+
     onMounted(() => {
       setTeamSchedules(), setMatchSchedules(), setFavorite(), setCompetitor()
     })
@@ -140,7 +170,9 @@ export default {
       favoriteMatches,
       firstCompetitorTeamsMatches,
       secondCompetitorTeamsMatches,
-      thirdCompetitorTeamsMatches
+      thirdCompetitorTeamsMatches,
+      date,
+      formatDate
     }
   }
 }

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -8,7 +8,7 @@
     <h2
       v-else
       class="is-size-2 has-text-centered has-text-weight-bold pb-6 has-text-danger">
-      20-21シーズンは終了しました
+      21-22シーズンは終了しました
     </h2>
     <div v-if="'2022-05-28' < formatDate(date)">
       <SeasonMessage />

--- a/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
+++ b/app/javascript/components/page/TeamSchedule/TeamSchedule.vue
@@ -10,18 +10,8 @@
       class="is-size-2 has-text-centered has-text-weight-bold pb-6 has-text-danger">
       20-21シーズンは終了しました
     </h2>
-    <div class="box" v-if="'2022-05-28' < formatDate(date)">
-      <p class="has-text-centered is-size-3 has-text-weight-bold">
-        ⚽️21-22シーズンの開幕予定🥅
-      </p>
-      <div class="mx-auto has-text-centered mt-3">
-        <ul class="is-size-5 has-text-weight-bold p-2">
-          <li>プレミア：8月 6日(土)</li>
-          <li>ラリーガ：8月12日(金)</li>
-          <li>ブンデス：8月 5日(金)</li>
-          <li>セリエA：未定</li>
-        </ul>
-      </div>
+    <div v-if="'2022-05-28' < formatDate(date)">
+      <SeasonMessage />
     </div>
     <MatchListLoader
       v-else-if="'2022-05-28' > formatDate(date) && !data.matches.length" />
@@ -66,12 +56,14 @@ import { reactive, onMounted, computed } from 'vue'
 import FavoriteTeamTable from '../../table/FavoriteTeamTable.vue'
 import CompetitorTeamTable from '../../table/CompetitorTeamTable.vue'
 import MatchListLoader from '../../loader/MatchListLoader'
+import SeasonMessage from '../TeamSchedule/message/SeasonCloseMessage.vue'
 
 export default {
   components: {
     MatchListLoader,
     FavoriteTeamTable,
-    CompetitorTeamTable
+    CompetitorTeamTable,
+    SeasonMessage
   },
   setup() {
     const data = reactive({

--- a/app/javascript/components/page/TeamSchedule/message/SeasonCloseMessage.vue
+++ b/app/javascript/components/page/TeamSchedule/message/SeasonCloseMessage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="box">
     <p class="has-text-centered is-size-3 has-text-weight-bold">
-      ⚽️ 21-22シーズンの開幕予定 🥅
+      ⚽️ 22-23シーズンの開幕予定 🥅
     </p>
     <div class="mx-auto has-text-centered mt-3">
       <ul class="is-size-5 has-text-weight-bold p-2">

--- a/app/javascript/components/page/TeamSchedule/message/SeasonCloseMessage.vue
+++ b/app/javascript/components/page/TeamSchedule/message/SeasonCloseMessage.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="box">
+    <p class="has-text-centered is-size-3 has-text-weight-bold">
+      ⚽️ 21-22シーズンの開幕予定 🥅
+    </p>
+    <div class="mx-auto has-text-centered mt-3">
+      <ul class="is-size-5 has-text-weight-bold p-2">
+        <li>プレミア：8月 6日(土)</li>
+        <li>ラリーガ：8月12日(金)</li>
+        <li>ブンデス：8月 5日(金)</li>
+        <li>セリエA：未定</li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/bin/lint
+++ b/bin/lint
@@ -3,3 +3,5 @@
 bundle exec rubocop -A
 bundle exec slim-lint app/views -c config/slim_lint.yml
 bin/yarn lint
+bin/yarn run prettier --write app/javascript
+


### PR DESCRIPTION
## 対応した issue
#127 
## 対応内容・対応背景・妥協点
- シーズン終了後に表示するものがないため、ローディングが常に表示される状態になっていた
- シーズンが終了したことを伝えるメッセージと各リーグの開幕予定を表示するようにした
- シーズン開始日と終了日が現時点でわからないため、日付は手動で入力した
## やったこと
- 日付を条件にシーズン終了のメッセージを表示するようにした
- 各リーグの開幕日を表示した
- 上記のメッセージをコンポーネント化した
## UI before / after
### before
<img width="1073" alt="Football" src="https://user-images.githubusercontent.com/62058863/170927367-52726a52-159e-448f-9ea2-73a73b42eb8a.png">

### after
<img width="1061" alt="Football" src="https://user-images.githubusercontent.com/62058863/170928267-91d12410-bc8c-4768-b64d-555dc6350d02.png">


## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
