### PR TITLE
フラッシュメッセージのレイアウトを変更

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,7 +26,7 @@ html
                 = link_to 'アカウントを作成', new_user_registration_path, class: 'has-text-white mx-2'
                 = link_to 'ログイン', new_user_session_path, class: 'has-text-white mx-2'
     p
-      .notice.is-size-5.p-3.has-text-success
+      .notice.is-size-4.p-5.has-text-centered.has-text-info
         = notice
     p
       .alert.is-size-4.p-5.has-text-centered.has-text-danger


### PR DESCRIPTION
## 対応した issue
#128 
## 対応内容・対応背景・妥協点
「ログインしました」のフラッシュメッセージがヘッダーと重なっていたので修正
## やったこと
- フラッシュメッセージのレイアウトを修正
## やってないこと
- 上記以外
## UI before / after
### before
<img width="1073" alt="Football" src="https://user-images.githubusercontent.com/62058863/170973176-02bae9dd-20a9-4157-b813-a07e2ed070f0.png">

### after
<img width="1052" alt="Football" src="https://user-images.githubusercontent.com/62058863/170973232-5b85e18d-14d3-4308-a42a-69bb3c77e399.png">

## テスト

- [x] `bin/lint`を実行した
- [x] `bundle exec rspec`を実行した
